### PR TITLE
chore: add Dependabot config and pin dependency versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "opencode-claude-max-proxy": "latest"
+    "opencode-claude-max-proxy": "^1.12.1"
   },
   "devDependencies": {
-    "@opencode-ai/plugin": "latest",
+    "@opencode-ai/plugin": "^1.2.27",
     "@types/node": "^25.5.0",
     "typescript": "^5.0.0"
   },


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with daily npm update checks
- Pin `opencode-claude-max-proxy` from `"latest"` to `"^1.12.1"`
- Pin `@opencode-ai/plugin` from `"latest"` to `"^1.2.27"`

This ensures Dependabot can track and propose version updates via PRs, and prevents unexpected breaking changes from `"latest"` resolution.