### PR TITLE
Windows plugin startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from "@opencode-ai/plugin"
 import { spawn, type ChildProcess } from "child_process"
-import { accessSync, constants } from "fs"
+import { createHash } from "crypto"
 import { createRequire } from "module"
 import { tmpdir } from "os"
 import path from "path"
@@ -37,27 +37,6 @@ function resolveProxyCommand(proxyBin: string): {
   command: string
   args: string[]
 } {
-  const shimName = process.platform === "win32"
-    ? "claude-max-proxy.cmd"
-    : "claude-max-proxy"
-  const shimPath = path.resolve(
-    path.dirname(proxyBin),
-    "..",
-    "..",
-    ".bin",
-    shimName
-  )
-
-  try {
-    accessSync(shimPath, constants.F_OK)
-    return {
-      command: shimPath,
-      args: [],
-    }
-  } catch {
-    // Fall through to direct execution.
-  }
-
   const extension = path.extname(proxyBin).toLowerCase()
 
   if (extension === ".js" || extension === ".cjs" || extension === ".mjs") {
@@ -189,10 +168,14 @@ export const ClaudeMaxPlugin: Plugin = async ({ client, $, directory }) => {
 
   // 4. Pick port
   const port = parseInt(process.env.CLAUDE_PROXY_PORT || "", 10) || DEFAULT_PORT
+  const sessionScope = createHash("sha256")
+    .update(directory)
+    .digest("hex")
+    .slice(0, 16)
   const sessionDir = path.join(
     tmpdir(),
     "opencode-with-claude",
-    `proxy-sessions-${process.pid}`
+    `proxy-sessions-${sessionScope}`
   )
 
   // 5. Spawn proxy


### PR DESCRIPTION
Summary:

Fixes: https://github.com/ianjwhite99/opencode-with-claude/issues/15

Problem:

The plugin doesn't work on Windows. 

Three independent issues:

1) resolveProxyBin() uses a forward-slash regex and template literal to build the proxy binary path. On Windows, require.resolve() returns backslash paths, so the resulting path is broken.
2) which claude doesn't exist on Windows.
3) stdio: "ignore" swallows all proxy output, so when any of the above fails, there's no diagnostic information in the logs.


There's also a fourth issue that affects all platforms: the proxy's shared session cache at ~/.cache/opencode-claude-max-proxy/sessions.json persists Claude SDK session IDs across restarts. When those sessions expire server-side, the proxy tries to resume a dead conversation and Claude returns No conversation found with session ID: ....

Changes:
- Use path.dirname() and path.join() instead of regex/template-literal path construction
- Run the proxy JS entrypoint through process.execPath (Node) explicitly instead of spawning the .js file directly
- Replace which claude with claude --version for CLI detection
- Pipe proxy stdout/stderr into plugin logs instead of discarding them
- Set CLAUDE_PROXY_SESSION_DIR to a per-workspace temp directory so each project gets its own session cache
- Add void to fire-and-forget log() calls (returns a Promise)
- Set explicit cwd on the spawned proxy process


Testing:
- Tested on Windows 11 with Node 22, opencode-claude-max-proxy@1.13.0. The proxy starts, passes health check, and proxies requests to Claude. Changes are backwards-compatible — path.dirname/path.join/claude --version all work on macOS and Linux.