### PR TITLE
fix: use default GITHUB_TOKEN for release-please

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,6 @@ jobs:
         id: release
         with:
           release-type: node
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The custom RELEASE_PLEASE_TOKEN lacked permission to create releases, causing "Resource not accessible by integration" errors.