### PR TITLE
feat: add session tracking headers via chat.headers hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,5 +24,10 @@ export const ClaudeMaxPlugin: Plugin = async ({ client, $, directory }) => {
       input.provider.anthropic.options.baseURL = baseURL
       input.provider.anthropic.options.apiKey = "claude-max-proxy"
     },
+    async "chat.headers"(incoming, output) {
+      if (incoming.model.providerID !== "anthropic") return
+      output.headers["x-opencode-session"] = incoming.sessionID
+      output.headers["x-opencode-request"] = incoming.message.id
+    },
   }
 }


### PR DESCRIPTION
Inject x-opencode-session and x-opencode-request headers into Anthropic API requests so the proxy can reliably map OpenCode sessions to Claude SDK sessions.