### PR TITLE
fix: add optional chaining for provider info access in chat.params

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export const ClaudeMaxPlugin: Plugin = async ({ client, $, directory }) => {
       input.provider.anthropic.options.apiKey = "claude-max-proxy"
     },
     async "chat.params"(incoming, output) {
-      if (incoming.provider.info.id !== "anthropic") return
+      if (incoming.provider?.info?.id !== "anthropic") return
 
       const health = await checkProxyHealth(proxy.port, log)
       if (!health.ok) {


### PR DESCRIPTION
Fixes #56 - 'undefined is not an object (evaluating r.provider.info.id)' when incoming.provider or incoming.provider.info is undefined.