### PR TITLE
feat: allow opencode-claude-max-proxy version specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ Global (`~/.config/opencode/opencode.json`) or project-level:
 opencode
 ```
 
+## Configuration
+
+| Environment Variable | Description | Default |
+|---|---|---|
+| `CLAUDE_PROXY_PORT` | Port for the local proxy server | `3456` |
+| `CLAUDE_PROXY_VERSION` | Pin a specific version of `opencode-claude-max-proxy` | Bundled version |
+
+### Pinning the proxy version
+
+By default the plugin uses the version of `opencode-claude-max-proxy` bundled with the package. To pin a specific version, set the `CLAUDE_PROXY_VERSION` environment variable:
+
+```bash
+CLAUDE_PROXY_VERSION=1.17.0 opencode
+```
+
+The requested version is installed to a local cache (`~/.cache/opencode-with-claude/`) on first use and reused on subsequent runs.
+
 ## Troubleshooting
 
 ### "Claude Code CLI not found"

--- a/bun.lock
+++ b/bun.lock
@@ -5,13 +5,13 @@
     "": {
       "name": "opencode-with-claude",
       "dependencies": {
-        "@rynfar/meridian": "latest",
+        "@rynfar/meridian": "^1.22.1",
       },
       "devDependencies": {
-        "@opencode-ai/plugin": "latest",
-        "@types/node": "latest",
-        "tsup": "latest",
-        "typescript": "latest",
+        "@opencode-ai/plugin": "^1.3.9",
+        "@types/node": "^25.5.0",
+        "tsup": "^8.5.1",
+        "typescript": "^6.0.2",
       },
     },
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,9 @@ export const ClaudeMaxPlugin: Plugin = async ({ client, $, directory }) => {
 
   const port =
     parseInt(process.env.CLAUDE_PROXY_PORT || "", 10) || undefined
+  const proxyVersion = process.env.CLAUDE_PROXY_VERSION || undefined
 
-  const proxy = await startProxy({ port, log })
+  const proxy = await startProxy({ port, proxyVersion, log })
 
   const baseURL = `http://127.0.0.1:${proxy.port}`
   await log("info", `proxy ready at ${baseURL}`)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,48 +1,100 @@
-import type { AddressInfo } from "net"
-import type { LogFn, LogLevel } from "./logger"
-import { startProxyServer } from "@rynfar/meridian"
+import type { AddressInfo } from "net";
+import type { LogFn, LogLevel } from "./logger";
+import { startProxyServer } from "@rynfar/meridian";
+import { resolve as resolvePath, join } from "path";
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { execSync } from "child_process";
 
-const IS_WINDOWS = process.platform === "win32"
+const IS_WINDOWS = process.platform === "win32";
 
 // ---------------------------------------------------------------------------
 // Proxy lifecycle
 // ---------------------------------------------------------------------------
 
 export interface StartProxyOptions {
-  port?: number
-  log: LogFn
+  port?: number;
+  proxyVersion?: string;
+  log: LogFn;
 }
 
 export interface ProxyHandle {
-  port: number
-  close(): Promise<void>
+  port: number;
+  close(): Promise<void>;
 }
 
-const DEFAULT_PORT = 3456
+const DEFAULT_PORT = 3456;
 
 const ERROR_PATTERNS =
-  /authenticat|credentials|expired|not logged in|exit(?:ed)? with code|crash|unhealthy|401|402|billing|subscription/i
+  /authenticat|credentials|expired|not logged in|exit(?:ed)? with code|crash|unhealthy|401|402|billing|subscription/i;
 const WARN_PATTERNS =
-  /rate.limit|429|overloaded|503|stale.session|timeout|timed out/i
+  /rate.limit|429|overloaded|503|stale.session|timeout|timed out/i;
 
 function classifyProxyLog(msg: string): LogLevel {
-  if (ERROR_PATTERNS.test(msg)) return "error"
-  if (WARN_PATTERNS.test(msg)) return "warn"
-  return "debug"
+  if (ERROR_PATTERNS.test(msg)) return "error";
+  if (WARN_PATTERNS.test(msg)) return "warn";
+  return "debug";
 }
 
-export async function startProxy(opts: StartProxyOptions): Promise<ProxyHandle> {
-  const { port = DEFAULT_PORT, log } = opts
+const CACHE_BASE = join(
+  process.env.XDG_CACHE_HOME || join(process.env.HOME || "~", ".cache"),
+  "opencode-with-claude",
+);
 
-  const origError = console.error
-  console.error = (...args: unknown[]) => {
-    const msg = args.map(String).join(" ")
-    if (msg.startsWith("[PROXY]")) {
-      void log(classifyProxyLog(msg), msg)
-      return
-    }
-    origError.apply(console, args)
+async function resolveProxyModule(
+  version: string | undefined,
+  log: LogFn,
+): Promise<{ startProxyServer: typeof startProxyServer }> {
+  if (!version) {
+    return await import("@rynfar/meridian");
   }
+
+  const cacheDir = join(CACHE_BASE, `proxy-${version}`);
+  const nodeModules = join(cacheDir, "node_modules");
+
+  if (!existsSync(join(nodeModules, "@rynfar/meridian"))) {
+    if (!/^[\w.^~>=<| -]+$/.test(version)) {
+      throw new Error(`Invalid CLAUDE_PROXY_VERSION: ${version}`);
+    }
+    await log(
+      "info",
+      `Installing @rynfar/meridian@${version} to ${cacheDir}...`,
+    );
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(
+      join(cacheDir, "package.json"),
+      JSON.stringify({
+        dependencies: { "@rynfar/meridian": version },
+      }),
+    );
+    execSync("npm install --no-audit --no-fund --loglevel=error", {
+      cwd: cacheDir,
+      stdio: "ignore",
+    });
+    await log("info", `Installed @rynfar/meridian@${version}`);
+  } else {
+    await log("info", `Using cached @rynfar/meridian@${version}`);
+  }
+
+  const resolved = resolvePath(cacheDir, "node_modules", "@rynfar/meridian");
+  return await import(resolved);
+}
+
+export async function startProxy(
+  opts: StartProxyOptions,
+): Promise<ProxyHandle> {
+  const { port = DEFAULT_PORT, proxyVersion, log } = opts;
+
+  const { startProxyServer } = await resolveProxyModule(proxyVersion, log);
+
+  const origError = console.error;
+  console.error = (...args: unknown[]) => {
+    const msg = args.map(String).join(" ");
+    if (msg.startsWith("[PROXY]")) {
+      void log(classifyProxyLog(msg), msg);
+      return;
+    }
+    origError.apply(console, args);
+  };
 
   const attempt = async (p: number) => {
     try {
@@ -50,7 +102,7 @@ export async function startProxy(opts: StartProxyOptions): Promise<ProxyHandle> 
         port: p,
         host: "127.0.0.1",
         silent: true,
-      })
+      });
     } catch (err) {
       if (
         p !== 0 &&
@@ -60,38 +112,38 @@ export async function startProxy(opts: StartProxyOptions): Promise<ProxyHandle> 
       ) {
         await log(
           "info",
-          `Port ${p} in use, starting on a random port instead...`
-        )
+          `Port ${p} in use, starting on a random port instead...`,
+        );
         return startProxyServer({
           port: 0,
           host: "127.0.0.1",
           silent: true,
-        })
+        });
       }
-      throw err
+      throw err;
     }
-  }
+  };
 
-  let proxy: Awaited<ReturnType<typeof startProxyServer>>
+  let proxy: Awaited<ReturnType<typeof startProxyServer>>;
   try {
-    proxy = await attempt(port)
+    proxy = await attempt(port);
   } catch (err) {
-    console.error = origError
-    throw err
+    console.error = origError;
+    throw err;
   }
 
-  const addr = proxy.server.address() as AddressInfo | null
-  const actualPort = addr?.port ?? proxy.config?.port ?? DEFAULT_PORT
+  const addr = proxy.server.address() as AddressInfo | null;
+  const actualPort = addr?.port ?? proxy.config?.port ?? DEFAULT_PORT;
 
-  await log("info", `Claude Max proxy running on port ${actualPort}`)
+  await log("info", `Claude Max proxy running on port ${actualPort}`);
 
   return {
     port: actualPort,
     close: async () => {
-      console.error = origError
-      await proxy.close()
+      console.error = origError;
+      await proxy.close();
     },
-  }
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -99,47 +151,46 @@ export async function startProxy(opts: StartProxyOptions): Promise<ProxyHandle> 
 // ---------------------------------------------------------------------------
 
 export interface HealthResult {
-  ok: boolean
-  message?: string
+  ok: boolean;
+  message?: string;
 }
 
 export async function checkProxyHealth(
   port: number,
-  log: LogFn
+  log: LogFn,
 ): Promise<HealthResult> {
   try {
     const res = await fetch(`http://127.0.0.1:${port}/health`, {
       signal: AbortSignal.timeout(5_000),
-    })
-    const body = await res.json() as Record<string, unknown>
+    });
+    const body = (await res.json()) as Record<string, unknown>;
 
-    if (body.status === "healthy") return { ok: true }
+    if (body.status === "healthy") return { ok: true };
 
     if (body.status === "degraded") {
       const detail =
         typeof body.error === "string"
           ? body.error
-          : "Could not verify auth status"
+          : "Could not verify auth status";
       await log(
         "warn",
-        `[claude-max] ${detail}. Requests may still work — if they hang, try running 'claude login' in your terminal.`
-      )
-      return { ok: true, message: detail }
+        `[claude-max] ${detail}. Requests may still work — if they hang, try running 'claude login' in your terminal.`,
+      );
+      return { ok: true, message: detail };
     }
 
     // "unhealthy" or unexpected status
     const detail =
       typeof body.error === "string"
         ? body.error
-        : `Proxy health check returned status: ${body.status ?? res.status}`
+        : `Proxy health check returned status: ${body.status ?? res.status}`;
 
-    await log("error", `[claude-max] ${detail}`)
-    return { ok: false, message: detail }
+    await log("error", `[claude-max] ${detail}`);
+    return { ok: false, message: detail };
   } catch (err) {
-    const msg =
-      err instanceof Error ? err.message : String(err)
-    await log("error", `[claude-max] Health check failed: ${msg}`)
-    return { ok: false, message: `Health check failed: ${msg}` }
+    const msg = err instanceof Error ? err.message : String(err);
+    await log("error", `[claude-max] Health check failed: ${msg}`);
+    return { ok: false, message: `Health check failed: ${msg}` };
   }
 }
 
@@ -148,18 +199,18 @@ export async function checkProxyHealth(
 // ---------------------------------------------------------------------------
 
 export function registerCleanup(proxy: ProxyHandle): void {
-  let cleaned = false
+  let cleaned = false;
 
   const cleanup = () => {
-    if (cleaned) return
-    cleaned = true
-    void proxy.close()
-  }
+    if (cleaned) return;
+    cleaned = true;
+    void proxy.close();
+  };
 
-  process.on("exit", cleanup)
-  process.on("SIGINT", cleanup)
+  process.on("exit", cleanup);
+  process.on("SIGINT", cleanup);
 
   if (!IS_WINDOWS) {
-    process.on("SIGTERM", cleanup)
+    process.on("SIGTERM", cleanup);
   }
 }


### PR DESCRIPTION
This is to allow users to pin a version of `opencode-claude-max-proxy` to avoid supply-chain attacks if `opencode-claude-max-proxy` is compromised and publishes a malicious version. (See ["Widespread Supply Chain Compromise Impacting npm Ecosystem"](https://www.cisa.gov/news-events/alerts/2025/09/23/widespread-supply-chain-compromise-impacting-npm-ecosystem))

Ever since this up-tick in supply-chain attacks on npm, I personally have switched to pinning every dependency everywhere to specified version, so a new version cannot be installed/executed without me manually updating. I would like to be able to do that with this plugin and its dependencies, and I'm sure many others would benefit from this as well.

Currently it is only possible to pin the version of this plugin, and not `opencode-claude-max-proxy`