### PR TITLE
fix: patch meridian SDK Bun detection to force node executable

### DIFF
--- a/src/patches/meridian-203.ts
+++ b/src/patches/meridian-203.ts
@@ -1,0 +1,27 @@
+/**
+ * Patches the claude-agent-sdk to not auto-detect Bun as the executable.
+ *
+ * OpenCode embeds Bun, so process.versions.bun is set — but `bun` may not
+ * be in PATH. The SDK uses this check to decide whether to spawn `bun cli.js`
+ * or `node cli.js`. We force it to always use node.
+ */
+
+import { readFileSync, writeFileSync } from "fs"
+import { dirname, join } from "path"
+import { fileURLToPath } from "url"
+
+export function applyMeridian203Patch(): boolean {
+  try {
+    const sdkEntry = fileURLToPath(import.meta.resolve("@anthropic-ai/claude-agent-sdk"))
+    const sdkPath = join(dirname(sdkEntry), "sdk.mjs")
+    const content = readFileSync(sdkPath, "utf8")
+
+    const target = "process.versions.bun!==void 0"
+    if (!content.includes(target)) return false
+
+    writeFileSync(sdkPath, content.replaceAll(target, "false"), "utf8")
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,11 @@
 import type { AddressInfo } from "net"
 import type { LogFn, LogLevel } from "./logger"
-import { startProxyServer } from "@rynfar/meridian"
+import { applyMeridian203Patch } from "./patches/meridian-203"
+
+// Patch the SDK's Bun detection before importing meridian.
+// Remove this block once meridian passes executable: "node" upstream.
+applyMeridian203Patch()
+const { startProxyServer } = await import("@rynfar/meridian")
 
 const IS_WINDOWS = process.platform === "win32"
 


### PR DESCRIPTION
## Problem

OpenCode embeds Bun, so `process.versions.bun` is set even though `bun` may not be in the user's PATH. The `@anthropic-ai/claude-agent-sdk` uses this check to decide whether to spawn `bun cli.js` or `node cli.js`, causing failures when Bun isn't available.

## Solution

- Added `src/patches/meridian-203.ts` — a runtime patch that rewrites the Bun detection check (`process.versions.bun!==void 0` → `false`) in the SDK's `sdk.mjs` before meridian is imported.
- Updated `src/proxy.ts` to apply the patch before dynamically importing meridian.

This can be removed once meridian passes `executable: "node"` upstream.