### PR TITLE
fix: enable disk profile discovery to read ~/.config/meridian/profiles.json

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,10 @@
 import type { AddressInfo } from "net"
 import  { classifyProxyLog, type LogFn } from "./logger"
-import { startProxyServer } from "@rynfar/meridian"
+import { startProxyServer, enableDiskProfileDiscovery } from "@rynfar/meridian"
+
+// Enable reading profiles from ~/.config/meridian/profiles.json
+// This must be called before startProxyServer() to load user-configured profiles
+enableDiskProfileDiscovery()
 
 // Enable passthrough mode so the proxy returns tool_use blocks to OpenCode
 // for execution, rather than running them internally. Without this, tool


### PR DESCRIPTION
## Summary

- Enables reading user-configured profiles from `~/.config/meridian/profiles.json`
- Calls `enableDiskProfileDiscovery()` before `startProxyServer()` to match Meridian CLI behavior

## Problem

The plugin wasn't detecting profiles configured in `~/.config/meridian/profiles.json`. This is because `@rynfar/meridian` requires calling `enableDiskProfileDiscovery()` before starting the proxy server to enable reading profiles from disk.

The Meridian CLI does this, but the plugin was missing this call.

## Solution

Import and call `enableDiskProfileDiscovery()` at module load time, before `startProxyServer()` is called.

## Testing

- Built successfully with `npm run build`
- Verified that profiles are now loaded from `~/.config/meridian/profiles.json`

Fixes #99