### PR TITLE
fix: strip anthropic-beta header for proxy requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
 
     async "chat.headers"(incoming, output) {
       if (incoming.model.providerID !== "anthropic") return
+      delete output.headers["anthropic-beta"]
       output.headers["x-opencode-session"] = incoming.sessionID
       output.headers["x-opencode-request"] = incoming.message.id
     },


### PR DESCRIPTION
## Summary
Strip the `anthropic-beta` header inside `opencode-with-claude` before requests are forwarded through the local Meridian proxy.

## Motivation
This plugin authenticates Anthropic traffic through the Claude/Meridian proxy path rather than direct Anthropic API-key usage. In that environment, custom beta headers can trigger warnings or request failures, while this package only needs to manage proxy routing and request correlation headers.

## Changes
- delete `anthropic-beta` in the Anthropic-only `chat.headers` hook
- keep the existing `x-opencode-session` and `x-opencode-request` headers unchanged
- leave core `opencode` and Copilot-related code untouched

## Testing
- `npm install` ✅
- `npm run build` ✅
- `lsp_diagnostics` on `src/index.ts` ✅
