### PR TITLE
fix: preserve AGENTS.md content in system prompt (#107)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
     // Inject the prompt for the current agent into the system prompt
     async "experimental.chat.system.transform"(input, output) {
       if (input.model.providerID !== "anthropic") return
-      output.system.splice(0, output.system.length, loadPrompt(currentAgent))
+      output.system.unshift(loadPrompt(currentAgent))
     },
 
     // Delete the anthropic-beta header and add session and request headers to the request for the proxy to identify the session and request


### PR DESCRIPTION
The experimental.chat.system.transform hook was using splice() to replace the entire system prompt array, wiping out AGENTS.md content that opencode had already injected. Changed to unshift() to prepend the plugin prompt while preserving existing system prompt entries.