### PR TITLE
fix: revert opencode prompt injection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
     // Inject the prompt for the current agent into the system prompt
     async "experimental.chat.system.transform"(input, output) {
       if (input.model.providerID !== "anthropic") return
-      output.system.unshift(loadPrompt(currentAgent))
+      output.system.splice(0, output.system.length, loadPrompt(currentAgent))
     },
 
     // Delete the anthropic-beta header and add session and request headers to the request for the proxy to identify the session and request


### PR DESCRIPTION
Changing splice to unshift caused the system prompt to leak, which anthropic detected as extra usage. Reverting until a proper fix can be added. 