### PR TITLE
fix: support configurable proxy host binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ This opens a browser for OAuth. Your Claude Max subscription credentials are nee
 2. Ensure your internet connection is working
 3. If using a manual port override, check if it's in use: `lsof -i :$CLAUDE_PROXY_PORT`
 
+### Binding the proxy to a non-localhost interface
+
+Meridian binds to `127.0.0.1` by default. If you need it to listen on another
+interface, set `CLAUDE_PROXY_HOST` (or Meridian's `MERIDIAN_HOST` alias) before
+starting OpenCode:
+
+```bash
+CLAUDE_PROXY_HOST=0.0.0.0 opencode serve --hostname 0.0.0.0 --port 4098
+```
+
+The plugin still uses loopback internally when you bind to wildcard addresses
+such as `0.0.0.0` or `::`, so local health checks and provider requests remain
+stable.
+
+Warning
+
+Exposing the proxy beyond localhost makes your authenticated Claude session
+reachable over the network. Only do this on trusted networks, and prefer
+firewall rules or other access controls if you open it up.
+
 ## Development
 
 ### Project Structure

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import type { Plugin } from "@opencode-ai/plugin"
 
 import { loadPrompt } from "./prompts"
 import { createLogger } from "./logger"
-import { registerCleanup, startProxy } from "./proxy"
+import { getProxyBaseURL, registerCleanup, startProxy } from "./proxy"
 
 export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
   const log = createLogger(client)
@@ -10,7 +10,7 @@ export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
   const port = process.env.CLAUDE_PROXY_PORT || 3456
   const proxy = await startProxy({ port, log })
 
-  const baseURL = `http://127.0.0.1:${proxy.port}`
+  const baseURL = getProxyBaseURL(proxy.port)
   void log("info", `proxy ready at ${baseURL}`)
   
   registerCleanup(proxy)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -24,9 +24,41 @@ export interface ProxyHandle {
 }
 
 const DEFAULT_PORT = 3456
+const DEFAULT_HOST = "127.0.0.1"
+
+function formatHostForUrl(host: string): string {
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host
+}
+
+export function getProxyHost(): string {
+  const host =
+    process.env.MERIDIAN_HOST?.trim() ||
+    process.env.CLAUDE_PROXY_HOST?.trim() ||
+    DEFAULT_HOST
+
+  return host.startsWith("[") && host.endsWith("]")
+    ? host.slice(1, -1)
+    : host
+}
+
+export function getProxyConnectHost(host = getProxyHost()): string {
+  // Wildcard bind addresses are not stable dial targets, so keep in-process
+  // traffic on loopback unless the user picked a concrete host.
+  if (host === "0.0.0.0") return DEFAULT_HOST
+  if (host === "::" || host === "[::]") return "::1"
+  return host
+}
+
+export function getProxyBaseURL(
+  port: string | number,
+  host = getProxyHost()
+): string {
+  return `http://${formatHostForUrl(getProxyConnectHost(host))}:${port}`
+}
 
 export async function startProxy(opts: StartProxyOptions): Promise<ProxyHandle> {
   const { port = DEFAULT_PORT, log } = opts
+  const host = getProxyHost()
 
   const origError = console.error
   console.error = (...args: unknown[]) => {
@@ -43,7 +75,7 @@ export async function startProxy(opts: StartProxyOptions): Promise<ProxyHandle> 
       (resolve, reject) => {
         startProxyServer({
           port: p,
-          host: "127.0.0.1",
+          host,
           silent: true,
         }).then((proxy) => {
           // EADDRINUSE is emitted asynchronously on the server – the
@@ -125,7 +157,7 @@ export async function checkProxyHealth(
   log: LogFn | undefined
 ): Promise<HealthResult> {
   try {
-    const res = await fetch(`http://127.0.0.1:${port}/health`, {
+    const res = await fetch(getProxyBaseURL(port) + "/health", {
       signal: AbortSignal.timeout(5_000),
     })
     const body = await res.json() as Record<string, unknown>


### PR DESCRIPTION
## Summary
- allow Meridian to bind to `CLAUDE_PROXY_HOST` or `MERIDIAN_HOST` instead of hardcoding `127.0.0.1`
- keep wildcard binds such as `0.0.0.0` and `::` on loopback for internal health checks and provider traffic
- document non-localhost proxy binding and the network exposure risk in the README

## Testing
- `npm run build`
- `node --test test/*.test.mjs`

Closes #121