### PR TITLE
feat: read meridian profiles and sdk-features from ~/.config/meridian

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,74 @@ Global (`~/.config/opencode/opencode.json`) or project-level:
 opencode
 ```
 
+## Profiles and SDK features
+
+The plugin now reads the same Meridian configuration files the `meridian` CLI
+uses, so you can maintain multiple Claude accounts and tune SDK behavior
+without leaving OpenCode.
+
+### Profiles (`~/.config/meridian/profiles.json`)
+
+Define one or more named profiles (for example, a personal Claude Max account
+and a work account). The plugin forwards them to Meridian at startup.
+
+```json
+[
+  {
+    "id": "personal",
+    "claudeConfigDir": "/Users/me/.config/meridian/profiles/personal"
+  },
+  {
+    "id": "work",
+    "claudeConfigDir": "/Users/me/.config/meridian/profiles/work"
+  }
+]
+```
+
+### Active profile (`~/.config/meridian/settings.json`)
+
+```json
+{ "activeProfile": "work" }
+```
+
+`activeProfile` selects the default profile for any request that does not send
+an explicit `x-meridian-profile` header. If the saved id is not in
+`profiles.json` (or the file is missing), the plugin logs a warning and falls
+back to the first configured profile.
+
+### SDK features (`~/.config/meridian/sdk-features.json`)
+
+Meridian reads this file lazily on every request, so overrides take effect
+without restarting the proxy. The plugin does not need to do anything special
+for it to work — just edit the file and the next request picks it up. See
+Meridian's documentation for the full list of adapter keys.
+
+```json
+{
+  "opencode": {
+    "memory": true,
+    "thinking": "enabled",
+    "maxBudgetUsd": 0.5
+  }
+}
+```
+
+### Environment overrides
+
+For parity with the `meridian` CLI:
+
+- `MERIDIAN_PROFILES` — JSON array of profile objects; wins over `profiles.json`.
+- `MERIDIAN_DEFAULT_PROFILE` — profile id; wins over `settings.activeProfile`.
+
+Malformed or missing files never crash the plugin; all parse/IO failures are
+logged via OpenCode's plugin log and the plugin falls back to no-profile mode.
+
+### Switching profiles at runtime
+
+Profile switching through Meridian's HTTP API continues to work — call
+`POST /profiles/active` on the proxy URL the plugin prints at startup. The
+selection is persisted back to `settings.json` and survives restarts.
+
 ## Troubleshooting
 
 ### "Claude Code CLI not found"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsup",
     "test": "./test/run.sh",
-    "test:unit": "npm run build && node --test test/*.test.mjs",
+    "test:unit": "npm run build && node --experimental-strip-types --test test/unit/*.test.mjs",
     "test:clean": "./test/run.sh --clean",
     "prepublishOnly": "npm run build"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,17 +2,27 @@ import type { Plugin } from "@opencode-ai/plugin"
 
 import { loadSystemPrompt } from "./prompts"
 import { createLogger } from "./logger"
+import { loadMeridianConfig, summarizeMeridianConfig } from "./meridian-config"
 import { getProxyBaseURL, registerCleanup, startProxy } from "./proxy"
 
 export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
   const log = createLogger(client)
 
+  const meridianConfig = loadMeridianConfig(log)
+  const summary = summarizeMeridianConfig(meridianConfig)
+  if (summary) void log("info", summary)
+
   const port = process.env.CLAUDE_PROXY_PORT || 3456
-  const proxy = await startProxy({ port, log })
+  const proxy = await startProxy({
+    port,
+    log,
+    profiles: meridianConfig.profiles,
+    defaultProfile: meridianConfig.defaultProfile,
+  })
 
   const baseURL = getProxyBaseURL(proxy.port)
   void log("info", `proxy ready at ${baseURL}`)
-  
+
   registerCleanup(proxy)
 
   let currentAgent: string

--- a/src/meridian-config.ts
+++ b/src/meridian-config.ts
@@ -1,0 +1,201 @@
+/**
+ * Load Meridian proxy configuration from disk so the plugin can forward
+ * it to `startProxyServer({ profiles, defaultProfile })`.
+ *
+ * Meridian's own CLI calls `enableDiskProfileDiscovery()` before starting
+ * the server, but that function is not re-exported from `@rynfar/meridian`'s
+ * public entry point and its private module has a hash-suffixed filename
+ * that drifts between releases. Instead we read the same files Meridian's
+ * CLI reads (`~/.config/meridian/profiles.json` and `settings.json`) and
+ * pass them through the supported `ProxyConfig` API.
+ *
+ * Precedence matches Meridian's CLI:
+ *   profiles:        MERIDIAN_PROFILES env var  >  profiles.json        >  []
+ *   defaultProfile:  MERIDIAN_DEFAULT_PROFILE   >  settings.activeProfile  >  undefined
+ *
+ * This is a leaf module — no imports from proxy.ts or index.ts.
+ */
+
+import { existsSync, readFileSync } from "fs"
+import { homedir } from "os"
+import { join } from "path"
+
+import type { LogFn } from "./logger.ts"
+
+export type ProfileType = "claude-max" | "api"
+
+export interface ProfileConfig {
+  /** Unique profile identifier (e.g. "personal", "work") */
+  id: string
+  /** Auth type — "claude-max" uses CLAUDE_CONFIG_DIR, "api" uses ANTHROPIC_API_KEY */
+  type?: ProfileType
+  /** Path to .claude config directory (claude-max profiles) */
+  claudeConfigDir?: string
+  /** Anthropic API key (api profiles) */
+  apiKey?: string
+  /** Anthropic base URL override (api profiles) */
+  baseUrl?: string
+}
+
+export interface MeridianConfigResult {
+  profiles: ProfileConfig[]
+  defaultProfile?: string
+  sources: {
+    profiles: "env" | "disk" | "none"
+    defaultProfile: "env" | "disk" | "none"
+  }
+}
+
+const MERIDIAN_DIR = () => join(homedir(), ".config", "meridian")
+const PROFILES_FILE = () => join(MERIDIAN_DIR(), "profiles.json")
+const SETTINGS_FILE = () => join(MERIDIAN_DIR(), "settings.json")
+
+function warn(log: LogFn | undefined, message: string): void {
+  void log?.("warn", `[opencode-with-claude] ${message}`)
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v)
+}
+
+/**
+ * Accept an unknown value and return only entries that look like a
+ * ProfileConfig. Drops malformed entries with a warning rather than
+ * throwing — matches Meridian's own "graceful degradation" posture.
+ */
+function sanitizeProfiles(
+  raw: unknown,
+  source: string,
+  log: LogFn | undefined,
+): ProfileConfig[] {
+  if (!Array.isArray(raw)) {
+    warn(log, `${source} must be a JSON array of profile objects; got ${typeof raw}. Ignoring.`)
+    return []
+  }
+  const out: ProfileConfig[] = []
+  for (const entry of raw) {
+    if (!isRecord(entry) || typeof entry.id !== "string" || !entry.id) {
+      warn(log, `${source}: dropping profile without a string "id" field.`)
+      continue
+    }
+    const p: ProfileConfig = { id: entry.id }
+    if (entry.type === "claude-max" || entry.type === "api") p.type = entry.type
+    if (typeof entry.claudeConfigDir === "string") p.claudeConfigDir = entry.claudeConfigDir
+    if (typeof entry.apiKey === "string") p.apiKey = entry.apiKey
+    if (typeof entry.baseUrl === "string") p.baseUrl = entry.baseUrl
+    out.push(p)
+  }
+  return out
+}
+
+function readJsonFile(path: string, log: LogFn | undefined): unknown {
+  if (!existsSync(path)) return undefined
+  try {
+    return JSON.parse(readFileSync(path, "utf8"))
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    warn(log, `failed to parse ${path}: ${msg}`)
+    return undefined
+  }
+}
+
+function loadProfilesFromEnv(log: LogFn | undefined): ProfileConfig[] | undefined {
+  const raw = process.env.MERIDIAN_PROFILES
+  if (!raw) return undefined
+  try {
+    return sanitizeProfiles(JSON.parse(raw), "MERIDIAN_PROFILES", log)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    warn(log, `failed to parse MERIDIAN_PROFILES env var: ${msg}`)
+    return undefined
+  }
+}
+
+function loadProfilesFromDisk(log: LogFn | undefined): ProfileConfig[] {
+  const raw = readJsonFile(PROFILES_FILE(), log)
+  if (raw === undefined) return []
+  return sanitizeProfiles(raw, PROFILES_FILE(), log)
+}
+
+function loadActiveProfileFromDisk(log: LogFn | undefined): string | undefined {
+  const raw = readJsonFile(SETTINGS_FILE(), log)
+  if (!isRecord(raw)) return undefined
+  const active = raw.activeProfile
+  if (active === undefined) return undefined
+  if (typeof active !== "string" || !active) {
+    warn(log, `${SETTINGS_FILE()}: "activeProfile" must be a non-empty string; ignoring.`)
+    return undefined
+  }
+  return active
+}
+
+/**
+ * Load profiles + default profile from disk/env with CLI-parity precedence.
+ * Never throws; all I/O and parse errors funnel through `log`.
+ */
+export function loadMeridianConfig(log?: LogFn): MeridianConfigResult {
+  let profiles: ProfileConfig[] = []
+  let profileSource: "env" | "disk" | "none" = "none"
+
+  const envProfiles = loadProfilesFromEnv(log)
+  if (envProfiles) {
+    profiles = envProfiles
+    profileSource = "env"
+  } else {
+    const diskProfiles = loadProfilesFromDisk(log)
+    if (diskProfiles.length > 0) {
+      profiles = diskProfiles
+      profileSource = "disk"
+    }
+  }
+
+  let defaultProfile: string | undefined
+  let defaultSource: "env" | "disk" | "none" = "none"
+
+  const envDefault = process.env.MERIDIAN_DEFAULT_PROFILE?.trim()
+  if (envDefault) {
+    defaultProfile = envDefault
+    defaultSource = "env"
+  } else {
+    const diskDefault = loadActiveProfileFromDisk(log)
+    if (diskDefault) {
+      defaultProfile = diskDefault
+      defaultSource = "disk"
+    }
+  }
+
+  // Validate: if we have profiles, the selected default must exist among them.
+  // Otherwise the proxy would silently fall back to the first profile for the
+  // wrong reason. Warn and drop the mismatched id.
+  if (
+    defaultProfile &&
+    profiles.length > 0 &&
+    !profiles.some((p) => p.id === defaultProfile)
+  ) {
+    warn(
+      log,
+      `default profile "${defaultProfile}" (from ${defaultSource}) not found among configured profiles; ignoring.`,
+    )
+    defaultProfile = undefined
+    defaultSource = "none"
+  }
+
+  return {
+    profiles,
+    defaultProfile,
+    sources: { profiles: profileSource, defaultProfile: defaultSource },
+  }
+}
+
+/**
+ * Build a short, human-readable summary of the loaded config for logging.
+ * Returns `undefined` when nothing was loaded (so callers can skip the log).
+ */
+export function summarizeMeridianConfig(cfg: MeridianConfigResult): string | undefined {
+  if (cfg.profiles.length === 0) return undefined
+  const ids = cfg.profiles.map((p) => p.id).join(", ")
+  const active = cfg.defaultProfile ?? cfg.profiles[0]?.id
+  const profSrc = cfg.sources.profiles
+  const activeSrc = cfg.sources.defaultProfile === "none" ? "first" : cfg.sources.defaultProfile
+  return `loaded ${cfg.profiles.length} meridian profile(s) from ${profSrc}: ${ids} (active: ${active} [${activeSrc}])`
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,6 @@
 import type { AddressInfo } from "net"
-import  { classifyProxyLog, type LogFn } from "./logger"
+import { classifyProxyLog, type LogFn } from "./logger.ts"
+import type { ProfileConfig } from "./meridian-config.ts"
 import { startProxyServer } from "@rynfar/meridian"
 
 // Enable passthrough mode so the proxy returns tool_use blocks to OpenCode
@@ -16,6 +17,10 @@ const IS_WINDOWS = process.platform === "win32"
 export interface StartProxyOptions {
   port?: string | number
   log: LogFn | undefined
+  /** Named auth profiles forwarded to Meridian's ProxyConfig. */
+  profiles?: ProfileConfig[]
+  /** Default profile id when no x-meridian-profile header is sent. */
+  defaultProfile?: string
 }
 
 export interface ProxyHandle {
@@ -57,7 +62,7 @@ export function getProxyBaseURL(
 }
 
 export async function startProxy(opts: StartProxyOptions): Promise<ProxyHandle> {
-  const { port = DEFAULT_PORT, log } = opts
+  const { port = DEFAULT_PORT, log, profiles, defaultProfile } = opts
   const host = getProxyHost()
 
   const origError = console.error
@@ -77,6 +82,8 @@ export async function startProxy(opts: StartProxyOptions): Promise<ProxyHandle> 
           port: p,
           host,
           silent: true,
+          profiles,
+          defaultProfile,
         }).then((proxy) => {
           // EADDRINUSE is emitted asynchronously on the server – the
           // promise from startProxyServer resolves before the error

--- a/test/unit/config-hook.test.mjs
+++ b/test/unit/config-hook.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 
-import * as pluginModule from "../dist/index.js"
+import * as pluginModule from "../../dist/index.js"
 
 test("bundle exports only the real plugin entry", () => {
   assert.deepEqual(Object.keys(pluginModule).sort(), ["ClaudeMaxPlugin"])

--- a/test/unit/helpers/profile-persistence-runner.mjs
+++ b/test/unit/helpers/profile-persistence-runner.mjs
@@ -1,0 +1,67 @@
+import { fileURLToPath } from "node:url"
+
+const mode = process.argv[2]
+const homeDir = process.argv[3]
+const targetProfile = process.argv[4]
+
+if (!mode || !homeDir) {
+  throw new Error("usage: node profile-persistence-runner.mjs <mode> <homeDir> [profileId]")
+}
+
+process.env.HOME = homeDir
+process.env.USERPROFILE = homeDir
+
+const meridianConfigModule = fileURLToPath(
+  new URL("../../../src/meridian-config.ts", import.meta.url),
+)
+const proxyModule = fileURLToPath(
+  new URL("../../../src/proxy.ts", import.meta.url),
+)
+
+const { loadMeridianConfig } = await import(meridianConfigModule)
+const { startProxy, getProxyBaseURL } = await import(proxyModule)
+
+const cfg = loadMeridianConfig()
+const proxy = await startProxy({
+  port: 0,
+  log: undefined,
+  profiles: cfg.profiles,
+  defaultProfile: cfg.defaultProfile,
+})
+
+try {
+  const baseURL = getProxyBaseURL(proxy.port)
+
+  if (mode === "switch") {
+    if (!targetProfile) throw new Error("switch mode requires a profile id")
+
+    const res = await fetch(`${baseURL}/profiles/active`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ profile: targetProfile }),
+      signal: AbortSignal.timeout(10_000),
+    })
+
+    if (!res.ok) {
+      throw new Error(`switch failed: ${res.status} ${await res.text()}`)
+    }
+
+    const body = await res.json()
+    process.stdout.write(JSON.stringify(body))
+  } else if (mode === "inspect") {
+    const res = await fetch(`${baseURL}/profiles/list`, {
+      signal: AbortSignal.timeout(10_000),
+    })
+
+    if (!res.ok) {
+      throw new Error(`inspect failed: ${res.status} ${await res.text()}`)
+    }
+
+    const body = await res.json()
+    process.stdout.write(JSON.stringify(body))
+  } else {
+    throw new Error(`unknown mode: ${mode}`)
+  }
+} finally {
+  await proxy.close()
+}

--- a/test/unit/logger.test.mjs
+++ b/test/unit/logger.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { classifyProxyLog } from "../../src/logger.ts"
+
+test("classifies authentication failures as error", () => {
+  assert.equal(classifyProxyLog("[PROXY] authentication failed"), "error")
+  assert.equal(classifyProxyLog("[PROXY] credentials invalid"), "error")
+  assert.equal(classifyProxyLog("[PROXY] Token expired"), "error")
+  assert.equal(classifyProxyLog("[PROXY] not logged in"), "error")
+})
+
+test("classifies HTTP 401/402 and billing/subscription issues as error", () => {
+  assert.equal(classifyProxyLog("[PROXY] 401 unauthorized"), "error")
+  assert.equal(classifyProxyLog("[PROXY] 402 payment required"), "error")
+  assert.equal(classifyProxyLog("[PROXY] billing issue"), "error")
+  assert.equal(classifyProxyLog("[PROXY] subscription inactive"), "error")
+})
+
+test("classifies crashes and exit codes as error", () => {
+  assert.equal(classifyProxyLog("[PROXY] process crashed"), "error")
+  assert.equal(classifyProxyLog("[PROXY] exited with code 1"), "error")
+  assert.equal(classifyProxyLog("[PROXY] exit with code 137"), "error")
+  assert.equal(classifyProxyLog("[PROXY] unhealthy"), "error")
+})
+
+test("classifies rate limits and transient outages as warn", () => {
+  assert.equal(classifyProxyLog("[PROXY] rate limit hit"), "warn")
+  assert.equal(classifyProxyLog("[PROXY] 429 Too Many Requests"), "warn")
+  assert.equal(classifyProxyLog("[PROXY] overloaded"), "warn")
+  assert.equal(classifyProxyLog("[PROXY] 503 service unavailable"), "warn")
+  assert.equal(classifyProxyLog("[PROXY] stale session detected"), "warn")
+  assert.equal(classifyProxyLog("[PROXY] request timed out"), "warn")
+})
+
+test("falls back to debug for neutral messages", () => {
+  assert.equal(classifyProxyLog("[PROXY] starting on port 3456"), "debug")
+  assert.equal(classifyProxyLog("[PROXY] received request"), "debug")
+  assert.equal(classifyProxyLog(""), "debug")
+  assert.equal(classifyProxyLog("some random text"), "debug")
+})
+
+test("pattern matching is case-insensitive", () => {
+  assert.equal(classifyProxyLog("[PROXY] AUTHENTICATION FAILED"), "error")
+  assert.equal(classifyProxyLog("[PROXY] Rate Limit Exceeded"), "warn")
+})
+
+test("when error and warn keywords both appear, error wins", () => {
+  // "expired" is an error signal; "rate limit" is a warn signal. The loader
+  // checks errors first so we should see error here.
+  assert.equal(
+    classifyProxyLog("[PROXY] token expired; rate limit backing off"),
+    "error",
+  )
+})

--- a/test/unit/meridian-config.test.mjs
+++ b/test/unit/meridian-config.test.mjs
@@ -1,0 +1,489 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+// The module under test reads from os.homedir(). We override HOME/USERPROFILE
+// for each test run so nothing escapes into the developer's real ~/.config.
+async function withFakeHome(setup) {
+  const dir = mkdtempSync(join(tmpdir(), "owc-meridian-"))
+  const meridianDir = join(dir, ".config", "meridian")
+  mkdirSync(meridianDir, { recursive: true })
+
+  const prevHome = process.env.HOME
+  const prevUserProfile = process.env.USERPROFILE
+  const prevProfiles = process.env.MERIDIAN_PROFILES
+  const prevDefault = process.env.MERIDIAN_DEFAULT_PROFILE
+
+  process.env.HOME = dir
+  process.env.USERPROFILE = dir
+  delete process.env.MERIDIAN_PROFILES
+  delete process.env.MERIDIAN_DEFAULT_PROFILE
+
+  try {
+    await setup(meridianDir)
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME
+    else process.env.HOME = prevHome
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE
+    else process.env.USERPROFILE = prevUserProfile
+    if (prevProfiles === undefined) delete process.env.MERIDIAN_PROFILES
+    else process.env.MERIDIAN_PROFILES = prevProfiles
+    if (prevDefault === undefined) delete process.env.MERIDIAN_DEFAULT_PROFILE
+    else process.env.MERIDIAN_DEFAULT_PROFILE = prevDefault
+
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+function collectLogs() {
+  const entries = []
+  const log = async (level, message) => {
+    entries.push({ level, message })
+  }
+  return { log, entries }
+}
+
+// Re-import with a cache-busting query so each test observes current env/fs.
+async function importLoader() {
+  return await import(`../../src/meridian-config.ts?t=${Date.now()}${Math.random()}`)
+}
+
+test("loads profiles from disk when no env vars are set", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([
+        { id: "personal", claudeConfigDir: "/tmp/p" },
+        { id: "work", claudeConfigDir: "/tmp/w" },
+      ]),
+    )
+    writeFileSync(
+      join(meridianDir, "settings.json"),
+      JSON.stringify({ activeProfile: "work" }),
+    )
+
+    const { loadMeridianConfig } = await importLoader()
+    const { log, entries } = collectLogs()
+    const cfg = loadMeridianConfig(log)
+
+    assert.equal(cfg.profiles.length, 2)
+    assert.deepEqual(
+      cfg.profiles.map((p) => p.id),
+      ["personal", "work"],
+    )
+    assert.equal(cfg.defaultProfile, "work")
+    assert.equal(cfg.sources.profiles, "disk")
+    assert.equal(cfg.sources.defaultProfile, "disk")
+    assert.equal(entries.length, 0, "no warnings on happy path")
+  })
+})
+
+test("MERIDIAN_PROFILES env wins over profiles.json", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([{ id: "disk-only" }]),
+    )
+    process.env.MERIDIAN_PROFILES = JSON.stringify([
+      { id: "env-one", type: "api", apiKey: "xxx" },
+      { id: "env-two" },
+    ])
+
+    const { loadMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+
+    assert.deepEqual(
+      cfg.profiles.map((p) => p.id),
+      ["env-one", "env-two"],
+    )
+    assert.equal(cfg.sources.profiles, "env")
+  })
+})
+
+test("MERIDIAN_DEFAULT_PROFILE env wins over settings.json", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([{ id: "a" }, { id: "b" }]),
+    )
+    writeFileSync(
+      join(meridianDir, "settings.json"),
+      JSON.stringify({ activeProfile: "a" }),
+    )
+    process.env.MERIDIAN_DEFAULT_PROFILE = "b"
+
+    const { loadMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+
+    assert.equal(cfg.defaultProfile, "b")
+    assert.equal(cfg.sources.defaultProfile, "env")
+  })
+})
+
+test("malformed profiles.json is logged and does not throw", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(join(meridianDir, "profiles.json"), "{not json")
+
+    const { loadMeridianConfig } = await importLoader()
+    const { log, entries } = collectLogs()
+    const cfg = loadMeridianConfig(log)
+
+    assert.deepEqual(cfg.profiles, [])
+    assert.equal(cfg.defaultProfile, undefined)
+    assert.equal(cfg.sources.profiles, "none")
+    assert.ok(entries.some((e) => e.level === "warn"), "expected a warn log")
+  })
+})
+
+test("malformed MERIDIAN_PROFILES env is logged and falls back to disk", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([{ id: "disk" }]),
+    )
+    process.env.MERIDIAN_PROFILES = "not valid json"
+
+    const { loadMeridianConfig } = await importLoader()
+    const { log, entries } = collectLogs()
+    const cfg = loadMeridianConfig(log)
+
+    assert.deepEqual(
+      cfg.profiles.map((p) => p.id),
+      ["disk"],
+    )
+    assert.equal(cfg.sources.profiles, "disk")
+    assert.ok(
+      entries.some((e) => e.message.includes("MERIDIAN_PROFILES")),
+      "expected a warn referencing MERIDIAN_PROFILES",
+    )
+  })
+})
+
+test("activeProfile not in profiles drops defaultProfile with a warn", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([{ id: "only-one" }]),
+    )
+    writeFileSync(
+      join(meridianDir, "settings.json"),
+      JSON.stringify({ activeProfile: "does-not-exist" }),
+    )
+
+    const { loadMeridianConfig } = await importLoader()
+    const { log, entries } = collectLogs()
+    const cfg = loadMeridianConfig(log)
+
+    assert.equal(cfg.profiles.length, 1)
+    assert.equal(cfg.defaultProfile, undefined)
+    assert.equal(cfg.sources.defaultProfile, "none")
+    assert.ok(
+      entries.some((e) => e.message.includes("does-not-exist")),
+      "expected a warn naming the missing profile",
+    )
+  })
+})
+
+test("profile entries without a string id are dropped with a warn", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([{ id: "good" }, { claudeConfigDir: "/tmp/bad" }, null]),
+    )
+
+    const { loadMeridianConfig } = await importLoader()
+    const { log, entries } = collectLogs()
+    const cfg = loadMeridianConfig(log)
+
+    assert.deepEqual(
+      cfg.profiles.map((p) => p.id),
+      ["good"],
+    )
+    assert.ok(entries.filter((e) => e.level === "warn").length >= 1)
+  })
+})
+
+test("missing config files return empty config with no warnings", async () => {
+  await withFakeHome(async () => {
+    const { loadMeridianConfig } = await importLoader()
+    const { log, entries } = collectLogs()
+    const cfg = loadMeridianConfig(log)
+
+    assert.deepEqual(cfg.profiles, [])
+    assert.equal(cfg.defaultProfile, undefined)
+    assert.equal(cfg.sources.profiles, "none")
+    assert.equal(cfg.sources.defaultProfile, "none")
+    assert.equal(entries.length, 0)
+  })
+})
+
+test("summarizeMeridianConfig formats a useful log line", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([{ id: "a" }, { id: "b" }]),
+    )
+    writeFileSync(
+      join(meridianDir, "settings.json"),
+      JSON.stringify({ activeProfile: "b" }),
+    )
+
+    const { loadMeridianConfig, summarizeMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+    const line = summarizeMeridianConfig(cfg)
+
+    assert.ok(line, "expected a summary string")
+    assert.match(line, /loaded 2 meridian profile/i)
+    assert.match(line, /\ba, b\b/)
+    assert.match(line, /active: b/)
+  })
+})
+
+test("summarizeMeridianConfig returns undefined when nothing is loaded", async () => {
+  await withFakeHome(async () => {
+    const { loadMeridianConfig, summarizeMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+    assert.equal(summarizeMeridianConfig(cfg), undefined)
+  })
+})
+
+// -----------------------------------------------------------------------------
+// Edge cases added for coverage tier 1
+// -----------------------------------------------------------------------------
+
+test("API profile round-trips type, apiKey, baseUrl", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([
+        {
+          id: "direct-api",
+          type: "api",
+          apiKey: "sk-ant-x",
+          baseUrl: "https://api.example.com",
+        },
+      ]),
+    )
+
+    const { loadMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+    assert.equal(cfg.profiles.length, 1)
+    assert.deepEqual(cfg.profiles[0], {
+      id: "direct-api",
+      type: "api",
+      apiKey: "sk-ant-x",
+      baseUrl: "https://api.example.com",
+    })
+  })
+})
+
+test("unknown profile type is stripped but profile is kept", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([
+        { id: "weird", type: "something-else", claudeConfigDir: "/tmp/w" },
+      ]),
+    )
+
+    const { loadMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+    assert.equal(cfg.profiles.length, 1)
+    assert.equal(cfg.profiles[0].id, "weird")
+    assert.equal(cfg.profiles[0].type, undefined, "unknown type should be stripped")
+    assert.equal(cfg.profiles[0].claudeConfigDir, "/tmp/w")
+  })
+})
+
+test("non-string scalar fields are dropped while the profile survives", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([
+        {
+          id: "mixed",
+          claudeConfigDir: 42,
+          apiKey: null,
+          baseUrl: { bogus: true },
+        },
+      ]),
+    )
+
+    const { loadMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+    assert.equal(cfg.profiles.length, 1)
+    assert.deepEqual(cfg.profiles[0], { id: "mixed" })
+  })
+})
+
+test("unknown top-level profile fields do not leak through", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([
+        {
+          id: "a",
+          extraField: "nope",
+          metadata: { anything: true },
+          claudeConfigDir: "/tmp/a",
+        },
+      ]),
+    )
+
+    const { loadMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+    assert.equal(cfg.profiles.length, 1)
+    assert.deepEqual(Object.keys(cfg.profiles[0]).sort(), [
+      "claudeConfigDir",
+      "id",
+    ])
+  })
+})
+
+test("MERIDIAN_PROFILES=\"\" is treated as unset and disk is consulted", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([{ id: "from-disk" }]),
+    )
+    process.env.MERIDIAN_PROFILES = ""
+
+    const { loadMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+    assert.deepEqual(
+      cfg.profiles.map((p) => p.id),
+      ["from-disk"],
+    )
+    assert.equal(cfg.sources.profiles, "disk")
+  })
+})
+
+test('MERIDIAN_PROFILES="[]" wins and prevents disk fallback (CLI parity)', async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([{ id: "disk-only" }]),
+    )
+    process.env.MERIDIAN_PROFILES = "[]"
+
+    const { loadMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+    assert.deepEqual(cfg.profiles, [])
+    assert.equal(
+      cfg.sources.profiles,
+      "env",
+      "empty env array should still be tagged as env source",
+    )
+  })
+})
+
+test('MERIDIAN_PROFILES="{}" (object, not array) logs a warn and is still env-sourced', async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([{ id: "disk-only" }]),
+    )
+    process.env.MERIDIAN_PROFILES = "{}"
+
+    const { loadMeridianConfig } = await importLoader()
+    const { log, entries } = collectLogs()
+    const cfg = loadMeridianConfig(log)
+    assert.deepEqual(cfg.profiles, [])
+    assert.equal(cfg.sources.profiles, "env")
+    assert.ok(
+      entries.some(
+        (e) => e.level === "warn" && e.message.includes("MERIDIAN_PROFILES"),
+      ),
+      "expected a warn naming MERIDIAN_PROFILES",
+    )
+  })
+})
+
+test("MERIDIAN_DEFAULT_PROFILE=whitespace is treated as unset", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([{ id: "a" }, { id: "b" }]),
+    )
+    writeFileSync(
+      join(meridianDir, "settings.json"),
+      JSON.stringify({ activeProfile: "a" }),
+    )
+    process.env.MERIDIAN_DEFAULT_PROFILE = "   "
+
+    const { loadMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+    assert.equal(cfg.defaultProfile, "a", "should fall through to settings.json")
+    assert.equal(cfg.sources.defaultProfile, "disk")
+  })
+})
+
+test("settings.json with non-object / non-string / empty-string activeProfile", async (t) => {
+  await t.test("settings.json as a top-level array is silently ignored", async () => {
+    await withFakeHome(async (meridianDir) => {
+      writeFileSync(
+        join(meridianDir, "profiles.json"),
+        JSON.stringify([{ id: "a" }]),
+      )
+      writeFileSync(join(meridianDir, "settings.json"), JSON.stringify([]))
+
+      const { loadMeridianConfig } = await importLoader()
+      const { log, entries } = collectLogs()
+      const cfg = loadMeridianConfig(log)
+      assert.equal(cfg.defaultProfile, undefined)
+      assert.equal(
+        entries.length,
+        0,
+        "unexpected shape should be silent, not warn",
+      )
+    })
+  })
+
+  await t.test("activeProfile=42 (non-string) warns and returns undefined", async () => {
+    await withFakeHome(async (meridianDir) => {
+      writeFileSync(
+        join(meridianDir, "profiles.json"),
+        JSON.stringify([{ id: "a" }]),
+      )
+      writeFileSync(
+        join(meridianDir, "settings.json"),
+        JSON.stringify({ activeProfile: 42 }),
+      )
+
+      const { loadMeridianConfig } = await importLoader()
+      const { log, entries } = collectLogs()
+      const cfg = loadMeridianConfig(log)
+      assert.equal(cfg.defaultProfile, undefined)
+      assert.ok(
+        entries.some(
+          (e) => e.level === "warn" && e.message.includes("activeProfile"),
+        ),
+        "expected a warn about activeProfile shape",
+      )
+    })
+  })
+
+  await t.test('activeProfile="" (empty string) warns and returns undefined', async () => {
+    await withFakeHome(async (meridianDir) => {
+      writeFileSync(
+        join(meridianDir, "profiles.json"),
+        JSON.stringify([{ id: "a" }]),
+      )
+      writeFileSync(
+        join(meridianDir, "settings.json"),
+        JSON.stringify({ activeProfile: "" }),
+      )
+
+      const { loadMeridianConfig } = await importLoader()
+      const { log, entries } = collectLogs()
+      const cfg = loadMeridianConfig(log)
+      assert.equal(cfg.defaultProfile, undefined)
+      assert.ok(
+        entries.some((e) => e.level === "warn"),
+        "expected a warn",
+      )
+    })
+  })
+})

--- a/test/unit/plugin-hooks.test.mjs
+++ b/test/unit/plugin-hooks.test.mjs
@@ -1,0 +1,290 @@
+import assert from "node:assert/strict"
+import test, { before, after } from "node:test"
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+} from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+// Tier-2 coverage: drive each plugin hook with a fake OpenCode client.
+// Runs a single real proxy instance for the whole file; the OS cleans it up
+// when the Node test runner exits (registerCleanup is wired to process exit).
+
+let hooks
+let fakeHomeDir
+let logEntries = []
+let previousEnv = {}
+
+function minifyPromptText(raw) {
+  return raw
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n")
+    .trim()
+}
+
+const expectedPlanPrompt = minifyPromptText(
+  readFileSync(new URL("../../src/prompts/anthropic/plan.txt", import.meta.url), "utf8"),
+)
+const expectedBuildPrompt = minifyPromptText(
+  readFileSync(new URL("../../src/prompts/anthropic/build.txt", import.meta.url), "utf8"),
+)
+
+function makeClient() {
+  return {
+    app: {
+      log: async ({ body }) => {
+        // Capture log output so we can assert against it if needed.
+        logEntries.push(body)
+        return {}
+      },
+    },
+  }
+}
+
+before(async () => {
+  // Isolate ~/.config/meridian and ~/.config/opencode so tests don't read
+  // the developer's real files.
+  fakeHomeDir = mkdtempSync(join(tmpdir(), "owc-hooks-"))
+  mkdirSync(join(fakeHomeDir, ".config", "meridian"), { recursive: true })
+  const opencodeDir = join(fakeHomeDir, ".config", "opencode")
+  mkdirSync(opencodeDir, { recursive: true })
+  // Plant an AGENTS.md we can look for in the transform-hook assertions.
+  writeFileSync(
+    join(opencodeDir, "AGENTS.md"),
+    "# Fake agents marker\nproject-specific instructions here.",
+  )
+
+  previousEnv = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    OPENCODE_CONFIG_DIR: process.env.OPENCODE_CONFIG_DIR,
+    XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+    CLAUDE_PROXY_PORT: process.env.CLAUDE_PROXY_PORT,
+  }
+
+  process.env.HOME = fakeHomeDir
+  process.env.USERPROFILE = fakeHomeDir
+  delete process.env.OPENCODE_CONFIG_DIR
+  delete process.env.XDG_CONFIG_HOME
+
+  // Use a random OS-assigned port so multiple runs don't collide.
+  process.env.CLAUDE_PROXY_PORT = "0"
+
+  const { ClaudeMaxPlugin } = await import(
+    `../../dist/index.js?t=${Date.now()}${Math.random()}`
+  )
+  hooks = await ClaudeMaxPlugin({ client: makeClient() })
+})
+
+after(async () => {
+  // ClaudeMaxPlugin starts the proxy internally but doesn't return its
+  // handle, so we trigger its registerCleanup() hook by emitting SIGINT
+  // and waiting a short tick for the async close() to drain the event loop.
+  // Without this, the open server keeps node:test from exiting.
+  process.emit("SIGINT")
+  await new Promise((resolve) => setTimeout(resolve, 250))
+
+  for (const [key, value] of Object.entries(previousEnv)) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+
+  rmSync(fakeHomeDir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// config hook
+// ---------------------------------------------------------------------------
+
+test("config hook rewrites provider.anthropic.options.baseURL to the proxy URL", async () => {
+  const input = {
+    provider: { anthropic: { options: { baseURL: "https://api.anthropic.com" } } },
+  }
+  await hooks.config(input)
+  assert.match(input.provider.anthropic.options.baseURL, /^http:\/\/.+:\d+$/)
+})
+
+test("config hook creates options when missing on the anthropic provider", async () => {
+  const input = { provider: { anthropic: {} } }
+  await hooks.config(input)
+  assert.ok(input.provider.anthropic.options)
+  assert.match(input.provider.anthropic.options.baseURL, /^http:\/\//)
+})
+
+test("config hook is a no-op when no anthropic provider exists", async () => {
+  const input = { provider: { openai: { options: { baseURL: "other" } } } }
+  await hooks.config(input)
+  assert.deepEqual(input, {
+    provider: { openai: { options: { baseURL: "other" } } },
+  })
+})
+
+// ---------------------------------------------------------------------------
+// chat.message hook — tracks the current agent for later transform hook
+// ---------------------------------------------------------------------------
+
+test("chat.message records the agent for anthropic requests", async () => {
+  // No direct getter — we confirm it via experimental.chat.system.transform
+  // below by first setting agent=plan, then transforming and checking output.
+  await hooks["chat.message"](
+    { model: { providerID: "anthropic" } },
+    { message: { agent: "plan" } },
+  )
+
+  const output = { system: ["original"] }
+  await hooks["experimental.chat.system.transform"](
+    { model: { providerID: "anthropic" } },
+    output,
+  )
+  assert.ok(Array.isArray(output.system))
+  assert.ok(output.system.length >= 1)
+  assert.equal(output.system[0], expectedPlanPrompt)
+})
+
+test("chat.message ignores non-anthropic providers", async () => {
+  // Setting agent=build for anthropic first …
+  await hooks["chat.message"](
+    { model: { providerID: "anthropic" } },
+    { message: { agent: "build" } },
+  )
+  // … then a non-anthropic call with a different agent should NOT overwrite it.
+  await hooks["chat.message"](
+    { model: { providerID: "openai" } },
+    { message: { agent: "plan" } },
+  )
+
+  const output = { system: [] }
+  await hooks["experimental.chat.system.transform"](
+    { model: { providerID: "anthropic" } },
+    output,
+  )
+  assert.ok(output.system.length >= 1)
+  assert.equal(output.system[0], expectedBuildPrompt)
+})
+
+// ---------------------------------------------------------------------------
+// experimental.chat.system.transform — drives the prompts module indirectly
+// ---------------------------------------------------------------------------
+
+test("system.transform replaces system[] for anthropic and includes AGENTS.md", async () => {
+  await hooks["chat.message"](
+    { model: { providerID: "anthropic" } },
+    { message: { agent: "build" } },
+  )
+
+  const output = { system: ["previous content that should be discarded"] }
+  await hooks["experimental.chat.system.transform"](
+    { model: { providerID: "anthropic" } },
+    output,
+  )
+
+  // Discarded the prior system content entirely.
+  assert.ok(
+    !output.system.some((s) => s.includes("previous content")),
+    "prior system content should be spliced out",
+  )
+  // Picked up the AGENTS.md we planted.
+  assert.ok(
+    output.system.some((s) => s.includes("Fake agents marker")),
+    "expected AGENTS.md content in transformed system array",
+  )
+  assert.equal(output.system[0], expectedBuildPrompt)
+  // At least [prompt, agents.md] — two non-empty entries.
+  assert.ok(output.system.length >= 2)
+  assert.ok(output.system.every((s) => typeof s === "string" && s.length > 0))
+})
+
+test("system.transform is a no-op for non-anthropic providers", async () => {
+  const output = { system: ["keep me intact"] }
+  await hooks["experimental.chat.system.transform"](
+    { model: { providerID: "openai" } },
+    output,
+  )
+  assert.deepEqual(output.system, ["keep me intact"])
+})
+
+test("system.transform falls back to build prompt for unknown agent names", async () => {
+  await hooks["chat.message"](
+    { model: { providerID: "anthropic" } },
+    { message: { agent: "does-not-exist" } },
+  )
+
+  const output = { system: [] }
+  await hooks["experimental.chat.system.transform"](
+    { model: { providerID: "anthropic" } },
+    output,
+  )
+  assert.ok(output.system.length >= 1)
+  assert.equal(output.system[0], expectedBuildPrompt)
+})
+
+// ---------------------------------------------------------------------------
+// chat.headers — strip anthropic-beta, add session/request headers
+// ---------------------------------------------------------------------------
+
+test("chat.headers strips anthropic-beta and adds session + request IDs", async () => {
+  const output = { headers: { "anthropic-beta": "some-flag", keep: "me" } }
+  await hooks["chat.headers"](
+    {
+      sessionID: "sess-123",
+      model: { providerID: "anthropic" },
+      message: { id: "msg-abc" },
+    },
+    output,
+  )
+  assert.equal(output.headers["anthropic-beta"], undefined)
+  assert.equal(output.headers["x-opencode-session"], "sess-123")
+  assert.equal(output.headers["x-opencode-request"], "msg-abc")
+  assert.equal(output.headers.keep, "me", "other headers should be preserved")
+})
+
+test("chat.headers is safe when anthropic-beta header was never present", async () => {
+  const output = { headers: {} }
+  await hooks["chat.headers"](
+    {
+      sessionID: "s",
+      model: { providerID: "anthropic" },
+      message: { id: "m" },
+    },
+    output,
+  )
+  assert.equal(output.headers["x-opencode-session"], "s")
+  assert.equal(output.headers["x-opencode-request"], "m")
+})
+
+test("chat.headers is a no-op for non-anthropic providers", async () => {
+  const output = { headers: { "anthropic-beta": "still-here" } }
+  await hooks["chat.headers"](
+    {
+      sessionID: "s",
+      model: { providerID: "openai" },
+      message: { id: "m" },
+    },
+    output,
+  )
+  assert.deepEqual(output.headers, { "anthropic-beta": "still-here" })
+})
+
+// ---------------------------------------------------------------------------
+// Logger instrumentation
+// ---------------------------------------------------------------------------
+
+test("plugin logs 'proxy ready' during startup", () => {
+  // The before-hook already invoked ClaudeMaxPlugin. One of the startup log
+  // entries should announce the proxy URL.
+  assert.ok(
+    logEntries.some(
+      (e) =>
+        e.service === "opencode-with-claude" &&
+        typeof e.message === "string" &&
+        e.message.startsWith("proxy ready at http://"),
+    ),
+    "expected a 'proxy ready at ...' log entry from startup",
+  )
+})

--- a/test/unit/proxy-auth.test.mjs
+++ b/test/unit/proxy-auth.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+// Coverage for Meridian's MERIDIAN_API_KEY gate. When the env var is set,
+// protected routes (including /profiles/list) require an x-api-key header.
+// The plugin doesn't set this key itself, but we want to confirm our wrapper
+// still surfaces the gate correctly so that users who configure it see the
+// expected 401/200 responses.
+
+async function withFakeHomeAndKey(setup, { apiKey }) {
+  const dir = mkdtempSync(join(tmpdir(), "owc-auth-"))
+  const meridianDir = join(dir, ".config", "meridian")
+  mkdirSync(meridianDir, { recursive: true })
+
+  const prev = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    MERIDIAN_API_KEY: process.env.MERIDIAN_API_KEY,
+  }
+
+  process.env.HOME = dir
+  process.env.USERPROFILE = dir
+  if (apiKey === undefined) delete process.env.MERIDIAN_API_KEY
+  else process.env.MERIDIAN_API_KEY = apiKey
+
+  try {
+    await setup(meridianDir)
+  } finally {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+async function freshImport(relPath) {
+  return await import(`${relPath}?t=${Date.now()}${Math.random()}`)
+}
+
+test("MERIDIAN_API_KEY set: /profiles/list without header returns 401", async () => {
+  await withFakeHomeAndKey(
+    async () => {
+      const { startProxy, getProxyBaseURL } = await freshImport(
+        "../../src/proxy.ts",
+      )
+      const proxy = await startProxy({ port: 0, log: undefined })
+
+      try {
+        const res = await fetch(`${getProxyBaseURL(proxy.port)}/profiles/list`, {
+          signal: AbortSignal.timeout(10_000),
+        })
+        assert.equal(res.status, 401)
+      } finally {
+        await proxy.close()
+      }
+    },
+    { apiKey: "test-secret-key" },
+  )
+})
+
+test("MERIDIAN_API_KEY set: /profiles/list with correct x-api-key returns 200", async () => {
+  await withFakeHomeAndKey(
+    async () => {
+      const { startProxy, getProxyBaseURL } = await freshImport(
+        "../../src/proxy.ts",
+      )
+      const proxy = await startProxy({ port: 0, log: undefined })
+
+      try {
+        const res = await fetch(`${getProxyBaseURL(proxy.port)}/profiles/list`, {
+          headers: { "x-api-key": "test-secret-key" },
+          signal: AbortSignal.timeout(10_000),
+        })
+        assert.equal(res.status, 200)
+      } finally {
+        await proxy.close()
+      }
+    },
+    { apiKey: "test-secret-key" },
+  )
+})

--- a/test/unit/proxy-helpers.test.mjs
+++ b/test/unit/proxy-helpers.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+// Pure-function coverage for the host/URL helpers in src/proxy.ts.
+// Each test snapshot-restores the env vars it touches so the suite stays
+// order-independent.
+
+async function freshImport() {
+  // Re-import with cache-busting so each test observes the current env.
+  return await import(`../../src/proxy.ts?t=${Date.now()}${Math.random()}`)
+}
+
+function withEnv(vars, fn) {
+  const prev = {}
+  for (const k of Object.keys(vars)) {
+    prev[k] = process.env[k]
+    if (vars[k] === undefined) delete process.env[k]
+    else process.env[k] = vars[k]
+  }
+  try {
+    return fn()
+  } finally {
+    for (const k of Object.keys(prev)) {
+      if (prev[k] === undefined) delete process.env[k]
+      else process.env[k] = prev[k]
+    }
+  }
+}
+
+test("getProxyHost: defaults to 127.0.0.1 when no env vars are set", async () => {
+  const { getProxyHost } = await freshImport()
+  await withEnv(
+    { MERIDIAN_HOST: undefined, CLAUDE_PROXY_HOST: undefined },
+    () => {
+      assert.equal(getProxyHost(), "127.0.0.1")
+    },
+  )
+})
+
+test("getProxyHost: MERIDIAN_HOST wins over CLAUDE_PROXY_HOST", async () => {
+  const { getProxyHost } = await freshImport()
+  await withEnv(
+    { MERIDIAN_HOST: "10.0.0.1", CLAUDE_PROXY_HOST: "10.0.0.2" },
+    () => {
+      assert.equal(getProxyHost(), "10.0.0.1")
+    },
+  )
+})
+
+test("getProxyHost: falls back to CLAUDE_PROXY_HOST when MERIDIAN_HOST is empty", async () => {
+  const { getProxyHost } = await freshImport()
+  await withEnv({ MERIDIAN_HOST: "", CLAUDE_PROXY_HOST: "192.168.1.1" }, () => {
+    assert.equal(getProxyHost(), "192.168.1.1")
+  })
+})
+
+test("getProxyHost: strips surrounding [] from bracketed IPv6 addresses", async () => {
+  const { getProxyHost } = await freshImport()
+  await withEnv({ MERIDIAN_HOST: "[::1]", CLAUDE_PROXY_HOST: undefined }, () => {
+    assert.equal(getProxyHost(), "::1")
+  })
+})
+
+test("getProxyHost: trims whitespace", async () => {
+  const { getProxyHost } = await freshImport()
+  await withEnv(
+    { MERIDIAN_HOST: "  1.2.3.4  ", CLAUDE_PROXY_HOST: undefined },
+    () => {
+      assert.equal(getProxyHost(), "1.2.3.4")
+    },
+  )
+})
+
+test('getProxyConnectHost: "0.0.0.0" is rewritten to loopback', async () => {
+  const { getProxyConnectHost } = await freshImport()
+  assert.equal(getProxyConnectHost("0.0.0.0"), "127.0.0.1")
+})
+
+test('getProxyConnectHost: "::" is rewritten to ::1', async () => {
+  const { getProxyConnectHost } = await freshImport()
+  assert.equal(getProxyConnectHost("::"), "::1")
+})
+
+test('getProxyConnectHost: "[::]" is rewritten to ::1', async () => {
+  const { getProxyConnectHost } = await freshImport()
+  assert.equal(getProxyConnectHost("[::]"), "::1")
+})
+
+test("getProxyConnectHost: concrete hosts pass through unchanged", async () => {
+  const { getProxyConnectHost } = await freshImport()
+  assert.equal(getProxyConnectHost("10.0.0.5"), "10.0.0.5")
+  assert.equal(getProxyConnectHost("example.com"), "example.com")
+  assert.equal(getProxyConnectHost("::1"), "::1")
+})
+
+test("getProxyBaseURL: IPv4 + numeric port", async () => {
+  const { getProxyBaseURL } = await freshImport()
+  assert.equal(getProxyBaseURL(3456, "127.0.0.1"), "http://127.0.0.1:3456")
+})
+
+test("getProxyBaseURL: IPv4 + string port", async () => {
+  const { getProxyBaseURL } = await freshImport()
+  assert.equal(getProxyBaseURL("3456", "127.0.0.1"), "http://127.0.0.1:3456")
+})
+
+test("getProxyBaseURL: IPv6 host is wrapped in brackets", async () => {
+  const { getProxyBaseURL } = await freshImport()
+  assert.equal(getProxyBaseURL(3456, "::1"), "http://[::1]:3456")
+})
+
+test("getProxyBaseURL: 0.0.0.0 folds to 127.0.0.1 for connections", async () => {
+  const { getProxyBaseURL } = await freshImport()
+  assert.equal(getProxyBaseURL(3456, "0.0.0.0"), "http://127.0.0.1:3456")
+})
+
+test("getProxyBaseURL: :: folds to [::1]", async () => {
+  const { getProxyBaseURL } = await freshImport()
+  assert.equal(getProxyBaseURL(3456, "::"), "http://[::1]:3456")
+})

--- a/test/unit/proxy-profiles.test.mjs
+++ b/test/unit/proxy-profiles.test.mjs
@@ -1,0 +1,307 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import test from "node:test"
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+} from "node:fs"
+import { fileURLToPath } from "node:url"
+import { join, resolve } from "node:path"
+import { tmpdir } from "node:os"
+
+// Integration test: start the proxy via our wrapper with profiles loaded from
+// a fake ~/.config/meridian, then verify the live /profiles endpoint serves
+// them. Directly reproduces the issue #99 user scenario end-to-end.
+
+async function withFakeHome(setup) {
+  const dir = mkdtempSync(join(tmpdir(), "owc-proxy-"))
+  const meridianDir = join(dir, ".config", "meridian")
+  mkdirSync(meridianDir, { recursive: true })
+
+  const prev = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    MERIDIAN_PROFILES: process.env.MERIDIAN_PROFILES,
+    MERIDIAN_DEFAULT_PROFILE: process.env.MERIDIAN_DEFAULT_PROFILE,
+  }
+
+  process.env.HOME = dir
+  process.env.USERPROFILE = dir
+  delete process.env.MERIDIAN_PROFILES
+  delete process.env.MERIDIAN_DEFAULT_PROFILE
+
+  try {
+    await setup(meridianDir)
+  } finally {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+async function freshImport(relPath) {
+  return await import(`${relPath}?t=${Date.now()}${Math.random()}`)
+}
+
+const profileRunnerPath = fileURLToPath(
+  new URL("./helpers/profile-persistence-runner.mjs", import.meta.url),
+)
+
+async function runProfilePersistenceHelper(mode, homeDir, profileId) {
+  return await new Promise((resolvePromise, reject) => {
+    const args = [
+      "--experimental-strip-types",
+      profileRunnerPath,
+      mode,
+      homeDir,
+    ]
+    if (profileId) args.push(profileId)
+
+    const child = spawn(process.execPath, args, {
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+
+    let stdout = ""
+    let stderr = ""
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk
+    })
+
+    child.on("error", reject)
+    child.on("exit", (code) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `profile helper failed (${mode}, exit ${code})\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+          ),
+        )
+        return
+      }
+
+      try {
+        resolvePromise(JSON.parse(stdout || "{}"))
+      } catch (err) {
+        reject(
+          new Error(
+            `profile helper returned invalid JSON (${mode})\nstdout:\n${stdout}\nstderr:\n${stderr}\nerror: ${err}`,
+          ),
+        )
+      }
+    })
+  })
+}
+
+test("live proxy /profiles reflects disk profiles and active selection", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([
+        { id: "personal", claudeConfigDir: join(meridianDir, "profiles", "personal") },
+        { id: "work", claudeConfigDir: join(meridianDir, "profiles", "work") },
+      ]),
+    )
+    writeFileSync(
+      join(meridianDir, "settings.json"),
+      JSON.stringify({ activeProfile: "work" }),
+    )
+
+    const { loadMeridianConfig } = await freshImport("../../src/meridian-config.ts")
+    const { startProxy, getProxyBaseURL } = await freshImport("../../src/proxy.ts")
+
+    const cfg = loadMeridianConfig()
+    const proxy = await startProxy({
+      port: 0,
+      log: undefined,
+      profiles: cfg.profiles,
+      defaultProfile: cfg.defaultProfile,
+    })
+
+    try {
+      const res = await fetch(`${getProxyBaseURL(proxy.port)}/profiles/list`, {
+        signal: AbortSignal.timeout(10_000),
+      })
+      assert.equal(res.status, 200, "GET /profiles/list should return 200")
+      const body = await res.json()
+
+      assert.ok(Array.isArray(body.profiles), "expected profiles array")
+      const ids = body.profiles.map((p) => p.id).sort()
+      assert.deepEqual(ids, ["personal", "work"])
+      assert.equal(body.activeProfile, "work")
+    } finally {
+      await proxy.close()
+    }
+  })
+})
+
+test("POST /profiles/active updates the active profile for subsequent requests", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([{ id: "personal" }, { id: "work" }]),
+    )
+    writeFileSync(
+      join(meridianDir, "settings.json"),
+      JSON.stringify({ activeProfile: "personal" }),
+    )
+
+    const { loadMeridianConfig } = await freshImport("../../src/meridian-config.ts")
+    const { startProxy, getProxyBaseURL } = await freshImport("../../src/proxy.ts")
+
+    const cfg = loadMeridianConfig()
+    const proxy = await startProxy({
+      port: 0,
+      log: undefined,
+      profiles: cfg.profiles,
+      defaultProfile: cfg.defaultProfile,
+    })
+
+    try {
+      const baseURL = getProxyBaseURL(proxy.port)
+
+      // Initial: personal is active.
+      let res = await fetch(`${baseURL}/profiles/list`, {
+        signal: AbortSignal.timeout(10_000),
+      })
+      let body = await res.json()
+      assert.equal(body.activeProfile, "personal")
+
+      // Flip to work.
+      res = await fetch(`${baseURL}/profiles/active`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ profile: "work" }),
+        signal: AbortSignal.timeout(10_000),
+      })
+      assert.equal(res.status, 200, "POST /profiles/active should return 200")
+      body = await res.json()
+      assert.equal(body.success, true)
+      assert.equal(body.activeProfile, "work")
+
+      // Re-fetch: the list reflects the new active profile.
+      res = await fetch(`${baseURL}/profiles/list`, {
+        signal: AbortSignal.timeout(10_000),
+      })
+      body = await res.json()
+      assert.equal(body.activeProfile, "work")
+      assert.ok(
+        body.profiles.find((p) => p.id === "work")?.isActive,
+        "work profile should be flagged as isActive",
+      )
+
+      // Meridian captures its settings path at module-load time, so asserting
+      // on-disk persistence inside this shared test process is brittle across
+      // the wider suite. The observable API behavior after switching is the
+      // important contract for this wrapper-level regression test.
+    } finally {
+      await proxy.close()
+    }
+  })
+})
+
+test("POST /profiles/active survives restart and is read on next startup", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([{ id: "personal" }, { id: "work" }]),
+    )
+    writeFileSync(
+      join(meridianDir, "settings.json"),
+      JSON.stringify({ activeProfile: "personal" }),
+    )
+
+    const homeDir = resolve(meridianDir, "..", "..")
+
+    const before = await runProfilePersistenceHelper("inspect", homeDir)
+    assert.equal(before.activeProfile, "personal")
+
+    const switched = await runProfilePersistenceHelper("switch", homeDir, "work")
+    assert.equal(switched.success, true)
+    assert.equal(switched.activeProfile, "work")
+
+    const after = await runProfilePersistenceHelper("inspect", homeDir)
+    assert.equal(
+      after.activeProfile,
+      "work",
+      "fresh startup should restore the switched profile from settings.json",
+    )
+    assert.ok(
+      after.profiles.find((p) => p.id === "work")?.isActive,
+      "work should still be the active profile after restart",
+    )
+  })
+})
+
+test("POST /profiles/active with an unknown id returns 400", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([{ id: "only" }]),
+    )
+
+    const { loadMeridianConfig } = await freshImport("../../src/meridian-config.ts")
+    const { startProxy, getProxyBaseURL } = await freshImport("../../src/proxy.ts")
+
+    const cfg = loadMeridianConfig()
+    const proxy = await startProxy({
+      port: 0,
+      log: undefined,
+      profiles: cfg.profiles,
+      defaultProfile: cfg.defaultProfile,
+    })
+
+    try {
+      const res = await fetch(`${getProxyBaseURL(proxy.port)}/profiles/active`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ profile: "does-not-exist" }),
+        signal: AbortSignal.timeout(10_000),
+      })
+      assert.equal(res.status, 400)
+      const body = await res.json()
+      assert.match(body.error, /Unknown profile/i)
+    } finally {
+      await proxy.close()
+    }
+  })
+})
+
+test("live proxy with no disk config reports no profiles", async () => {
+  await withFakeHome(async () => {
+    const { loadMeridianConfig } = await freshImport("../../src/meridian-config.ts")
+    const { startProxy, getProxyBaseURL } = await freshImport("../../src/proxy.ts")
+
+    const cfg = loadMeridianConfig()
+    assert.equal(cfg.profiles.length, 0)
+
+    const proxy = await startProxy({
+      port: 0,
+      log: undefined,
+      profiles: cfg.profiles,
+      defaultProfile: cfg.defaultProfile,
+    })
+
+    try {
+      const res = await fetch(`${getProxyBaseURL(proxy.port)}/profiles/list`, {
+        signal: AbortSignal.timeout(10_000),
+      })
+      assert.equal(res.status, 200)
+      const body = await res.json()
+      assert.deepEqual(body.profiles, [])
+    } finally {
+      await proxy.close()
+    }
+  })
+})

--- a/test/unit/proxy-sdk-features.test.mjs
+++ b/test/unit/proxy-sdk-features.test.mjs
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+// Regression test: Meridian reads ~/.config/meridian/sdk-features.json lazily
+// at request time, so the plugin needs no init hook to honor it. This test
+// plants an overriding sdk-features.json under a fake HOME and verifies that
+// the live proxy's /features endpoint reflects the overrides.
+
+async function withFakeHome(setup) {
+  const dir = mkdtempSync(join(tmpdir(), "owc-sdkfeat-"))
+  const meridianDir = join(dir, ".config", "meridian")
+  mkdirSync(meridianDir, { recursive: true })
+
+  const prevHome = process.env.HOME
+  const prevUserProfile = process.env.USERPROFILE
+  process.env.HOME = dir
+  process.env.USERPROFILE = dir
+
+  try {
+    await setup(meridianDir)
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME
+    else process.env.HOME = prevHome
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE
+    else process.env.USERPROFILE = prevUserProfile
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+async function freshImport(relPath) {
+  return await import(`${relPath}?t=${Date.now()}${Math.random()}`)
+}
+
+test("sdk-features.json overrides surface on /features without any plugin init", async () => {
+  await withFakeHome(async (meridianDir) => {
+    // Override a well-known scalar we can assert on later. `memory` is a
+    // boolean default so we flip it to verify the override is picked up.
+    writeFileSync(
+      join(meridianDir, "sdk-features.json"),
+      JSON.stringify({
+        opencode: {
+          memory: true,
+          maxBudgetUsd: 0.5,
+        },
+      }),
+    )
+
+    const { startProxy, getProxyBaseURL } = await freshImport("../../src/proxy.ts")
+    const proxy = await startProxy({ port: 0, log: undefined })
+
+    try {
+      const res = await fetch(
+        `${getProxyBaseURL(proxy.port)}/settings/api/features`,
+        { signal: AbortSignal.timeout(10_000) },
+      )
+      assert.equal(
+        res.status,
+        200,
+        "GET /settings/api/features should return 200",
+      )
+      const body = await res.json()
+
+      assert.ok(
+        body && typeof body === "object",
+        "expected an adapters map in the response",
+      )
+
+      const opencode = body.opencode
+      assert.ok(opencode, "expected an 'opencode' adapter entry")
+      assert.equal(opencode.memory, true, "memory override should be honored")
+      assert.equal(
+        opencode.maxBudgetUsd,
+        0.5,
+        "maxBudgetUsd override should be honored",
+      )
+    } finally {
+      await proxy.close()
+    }
+  })
+})
+
+test("PATCH /settings/api/features/:adapter persists to sdk-features.json", async () => {
+  await withFakeHome(async (meridianDir) => {
+    // Seed the same base config as the read-path test so Meridian's module-
+    // level cache cannot smear unrelated state into this assertion.
+    writeFileSync(
+      join(meridianDir, "sdk-features.json"),
+      JSON.stringify({
+        opencode: {
+          memory: true,
+          maxBudgetUsd: 0.5,
+        },
+      }),
+    )
+
+    const { startProxy, getProxyBaseURL } = await freshImport("../../src/proxy.ts")
+    const proxy = await startProxy({ port: 0, log: undefined })
+
+    try {
+      const baseURL = getProxyBaseURL(proxy.port)
+
+      // Apply an override via the HTTP API.
+      let res = await fetch(`${baseURL}/settings/api/features/opencode`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ memory: true, thinking: "enabled" }),
+        signal: AbortSignal.timeout(10_000),
+      })
+      assert.equal(res.status, 200, "PATCH should return 200")
+      const patchBody = await res.json()
+      assert.equal(patchBody.ok, true)
+
+      // Re-GET: the override is visible.
+      res = await fetch(`${baseURL}/settings/api/features`, {
+        signal: AbortSignal.timeout(10_000),
+      })
+      assert.equal(res.status, 200)
+      const body = await res.json()
+      assert.equal(body.opencode.memory, true)
+      assert.equal(body.opencode.thinking, "enabled")
+      assert.equal(body.opencode.maxBudgetUsd, 0.5)
+
+      assert.ok(
+        existsSync(join(meridianDir, "sdk-features.json")),
+        "PATCH should have written sdk-features.json",
+      )
+      const persisted = JSON.parse(
+        readFileSync(join(meridianDir, "sdk-features.json"), "utf8"),
+      )
+      assert.deepEqual(persisted, {
+        opencode: {
+          memory: true,
+          maxBudgetUsd: 0.5,
+          thinking: "enabled",
+        },
+      })
+    } finally {
+      await proxy.close()
+    }
+  })
+})
+
+test("PATCH with invalid value returns 400 and does not write the file", async () => {
+  await withFakeHome(async (meridianDir) => {
+    const { startProxy, getProxyBaseURL } = await freshImport("../../src/proxy.ts")
+    const proxy = await startProxy({ port: 0, log: undefined })
+
+    try {
+      const res = await fetch(
+        `${getProxyBaseURL(proxy.port)}/settings/api/features/opencode`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ thinking: "not-a-valid-value" }),
+          signal: AbortSignal.timeout(10_000),
+        },
+      )
+      assert.equal(res.status, 400)
+      const body = await res.json()
+      assert.ok(body.error, "expected an error message in the response")
+
+      // The write should never have happened (no file, or unchanged file).
+      const path = join(meridianDir, "sdk-features.json")
+      if (existsSync(path)) {
+        const persisted = JSON.parse(readFileSync(path, "utf8"))
+        assert.equal(
+          persisted.opencode?.thinking,
+          undefined,
+          "invalid value should not have been persisted",
+        )
+      }
+    } finally {
+      await proxy.close()
+    }
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## Summary

Fixes the plugin's handling of Meridian configuration files so it behaves like the `meridian` CLI:

- Reads `~/.config/meridian/profiles.json` at startup and forwards the profiles to the proxy via `ProxyConfig.profiles`.
- Reads `~/.config/meridian/settings.json` → `activeProfile` and passes it as `defaultProfile`.
- Honors `MERIDIAN_PROFILES` / `MERIDIAN_DEFAULT_PROFILE` env overrides (env > disk, matching CLI precedence).
- `sdk-features.json` was already picked up lazily by Meridian at request time; this PR adds a regression test to lock that in.

## Why the issue's one-line fix wouldn't compile

The reporter's suggested `import { enableDiskProfileDiscovery } from "@rynfar/meridian"` isn't viable: Meridian's `package.json` only exports `./dist/server.js` (narrow re-export list), and the profile functions live in a hash-named module (`profiles-<hash>.js`) behind the `exports` gate. Instead we read the same files the CLI reads and pass them through the supported `startProxyServer({ profiles, defaultProfile })` API — no private-API dependency.

## Changes

- **`src/meridian-config.ts` (new)** — loader that reads `profiles.json` and `settings.json` with CLI-parity env overrides. Never throws; all I/O and parse errors funnel through the plugin's logger. Drops malformed entries with a warn. Validates that the selected default profile actually exists among configured profiles.
- **`src/index.ts`** — invokes the loader, logs a one-line summary when profiles are discovered, forwards to `startProxy`.
- **`src/proxy.ts`** — `StartProxyOptions` now accepts `profiles` + `defaultProfile`, passed straight through to `startProxyServer`.
- **`README.md`** — new 'Profiles and SDK features' section covering config paths, env overrides, and runtime switching via `POST /profiles/active`.

## Tests (67 total, all passing)

Tests now import `.ts` source directly using `node --experimental-strip-types`, so no dist-test bloat in the published package.

- **Loader (19 tests)** — happy path, env precedence, malformed JSON in either file, missing files, mismatched `activeProfile`, non-string fields dropped, unknown fields dropped, whitespace env, `MERIDIAN_PROFILES=\"\"` / `\"[]\"` / `\"{}\"`, non-object `settings.json`, non-string `activeProfile`, summary formatting.
- **Proxy helpers** — `getProxyHost`, `getProxyConnectHost`, `getProxyBaseURL` across IPv4/IPv6/wildcard hosts, env precedence, bracket stripping.
- **Logger** — `classifyProxyLog` pattern routing (error/warn/debug) with case-insensitivity and priority when both keyword classes appear.
- **Integration (live proxy)** — `/profiles/list` reflects disk profiles + active selection; `POST /profiles/active` switches the active profile (in-memory); unknown profile id returns 400; `sdk-features.json` overrides surface on `/settings/api/features`; `PATCH` round-trip; `PATCH` with invalid value returns 400; `MERIDIAN_API_KEY` gate (401 without header, 200 with correct `x-api-key`).
- **Plugin hooks** — `config` baseURL rewrite (with and without `options`, no-op when no anthropic provider), `chat.message` anthropic/non-anthropic routing, `experimental.chat.system.transform` replaces system array and picks up AGENTS.md, unknown-agent fallback to build prompt, `chat.headers` strips `anthropic-beta` and injects session/request IDs.
- **Bundle shape** — dist still ships only `ClaudeMaxPlugin`.

## Scope / non-goals

- No vendoring or patching of Meridian internals.
- `~/.config/meridian` paths match Meridian exactly (no XDG_CONFIG_HOME divergence).
- Runtime profile switching continues to go through Meridian's `POST /profiles/active`.
- Meridian minimum version unchanged.

Closes #99