### PR TITLE
fix: update meridian for Linux Claude launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@rynfar/meridian": "^1.38.0"
+    "@rynfar/meridian": "^1.40.0"
   },
   "devDependencies": {
     "@opencode-ai/plugin": "^1.14.22",


### PR DESCRIPTION
Bump Meridian to a release that resolves Claude through the correct bundled Linux launcher path. This avoids the ENOEXEC failure reported in #128 during packaged plugin installs on Linux.