### PR TITLE
fix: default opencode client prompt off

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,14 @@ without restarting the proxy. The plugin does not need to do anything special
 for it to work — just edit the file and the next request picks it up. See
 Meridian's documentation for the full list of adapter keys.
 
+This plugin defaults OpenCode's client prompt off because forwarding the
+OpenCode prompt can cause Claude Max requests to be classified as third-party
+usage. You can re-enable it by setting `clientSystemPrompt` to `true`.
+
 ```json
 {
   "opencode": {
+    "clientSystemPrompt": false,
     "memory": true,
     "thinking": "enabled",
     "maxBudgetUsd": 0.5

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 import type { Plugin } from "@opencode-ai/plugin"
 
 import { createLogger } from "./logger"
-import { loadMeridianConfig, summarizeMeridianConfig } from "./meridian-config"
+import {
+  ensureOpenCodeClientPromptDefault,
+  loadMeridianConfig,
+  summarizeMeridianConfig,
+} from "./meridian-config"
 import { getProxyBaseURL, registerCleanup, startProxy } from "./proxy"
 
 export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
@@ -10,6 +14,8 @@ export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
   const meridianConfig = loadMeridianConfig(log)
   const summary = summarizeMeridianConfig(meridianConfig)
   if (summary) void log("info", summary)
+
+  ensureOpenCodeClientPromptDefault(log)
 
   const port = process.env.CLAUDE_PROXY_PORT || 3456
   const proxy = await startProxy({

--- a/src/meridian-config.ts
+++ b/src/meridian-config.ts
@@ -16,7 +16,7 @@
  * This is a leaf module — no imports from proxy.ts or index.ts.
  */
 
-import { existsSync, readFileSync } from "fs"
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs"
 import { homedir } from "os"
 import { join } from "path"
 
@@ -49,6 +49,7 @@ export interface MeridianConfigResult {
 const MERIDIAN_DIR = () => join(homedir(), ".config", "meridian")
 const PROFILES_FILE = () => join(MERIDIAN_DIR(), "profiles.json")
 const SETTINGS_FILE = () => join(MERIDIAN_DIR(), "settings.json")
+const SDK_FEATURES_FILE = () => join(MERIDIAN_DIR(), "sdk-features.json")
 
 function warn(log: LogFn | undefined, message: string): void {
   void log?.("warn", `[opencode-with-claude] ${message}`)
@@ -198,4 +199,51 @@ export function summarizeMeridianConfig(cfg: MeridianConfigResult): string | und
   const profSrc = cfg.sources.profiles
   const activeSrc = cfg.sources.defaultProfile === "none" ? "first" : cfg.sources.defaultProfile
   return `loaded ${cfg.profiles.length} meridian profile(s) from ${profSrc}: ${ids} (active: ${active} [${activeSrc}])`
+}
+
+/**
+ * OpenCode's system prompt can cause Claude Max traffic to be classified as
+ * third-party usage. Default the client prompt off while preserving any user
+ * override written through Meridian's settings UI or sdk-features.json.
+ */
+export function ensureOpenCodeClientPromptDefault(log?: LogFn): void {
+  const path = SDK_FEATURES_FILE()
+  let config: Record<string, unknown> = {}
+
+  if (existsSync(path)) {
+    const raw = readJsonFile(path, log)
+    if (raw === undefined) return
+    if (!isRecord(raw)) {
+      warn(log, `${path} must be a JSON object; leaving client prompt default unchanged.`)
+      return
+    }
+    config = raw
+  }
+
+  const current = config.opencode
+  if (current !== undefined && !isRecord(current)) {
+    warn(log, `${path}: "opencode" must be a JSON object; leaving client prompt default unchanged.`)
+    return
+  }
+
+  const opencode = current ?? {}
+  if (Object.hasOwn(opencode, "clientSystemPrompt")) return
+
+  const nextConfig = {
+    ...config,
+    opencode: {
+      ...opencode,
+      clientSystemPrompt: false,
+    },
+  }
+
+  try {
+    mkdirSync(MERIDIAN_DIR(), { recursive: true })
+    const tmp = `${path}.tmp`
+    writeFileSync(tmp, JSON.stringify(nextConfig, null, 2))
+    renameSync(tmp, path)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    warn(log, `failed to update ${path}: ${msg}`)
+  }
 }

--- a/test/unit/meridian-config.test.mjs
+++ b/test/unit/meridian-config.test.mjs
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict"
 import test from "node:test"
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+} from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 
@@ -216,6 +223,59 @@ test("missing config files return empty config with no warnings", async () => {
     assert.equal(cfg.sources.profiles, "none")
     assert.equal(cfg.sources.defaultProfile, "none")
     assert.equal(entries.length, 0)
+  })
+})
+
+test("defaults OpenCode client prompt off when sdk-features.json is missing", async () => {
+  await withFakeHome(async (meridianDir) => {
+    const { ensureOpenCodeClientPromptDefault } = await importLoader()
+    ensureOpenCodeClientPromptDefault()
+
+    const path = join(meridianDir, "sdk-features.json")
+    assert.equal(existsSync(path), true)
+    assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), {
+      opencode: { clientSystemPrompt: false },
+    })
+  })
+})
+
+test("defaults OpenCode client prompt off without clobbering other SDK features", async () => {
+  await withFakeHome(async (meridianDir) => {
+    const path = join(meridianDir, "sdk-features.json")
+    writeFileSync(
+      path,
+      JSON.stringify({
+        opencode: { memory: true },
+        crush: { clientSystemPrompt: true },
+      }),
+    )
+
+    const { ensureOpenCodeClientPromptDefault } = await importLoader()
+    ensureOpenCodeClientPromptDefault()
+
+    assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), {
+      opencode: { memory: true, clientSystemPrompt: false },
+      crush: { clientSystemPrompt: true },
+    })
+  })
+})
+
+test("preserves explicit OpenCode client prompt setting", async () => {
+  await withFakeHome(async (meridianDir) => {
+    const path = join(meridianDir, "sdk-features.json")
+    writeFileSync(
+      path,
+      JSON.stringify({
+        opencode: { clientSystemPrompt: true, memory: true },
+      }),
+    )
+
+    const { ensureOpenCodeClientPromptDefault } = await importLoader()
+    ensureOpenCodeClientPromptDefault()
+
+    assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), {
+      opencode: { clientSystemPrompt: true, memory: true },
+    })
   })
 })
 

--- a/test/unit/plugin-hooks.test.mjs
+++ b/test/unit/plugin-hooks.test.mjs
@@ -3,6 +3,7 @@ import test, { before, after } from "node:test"
 import {
   mkdtempSync,
   mkdirSync,
+  readFileSync,
   rmSync,
 } from "node:fs"
 import { join } from "node:path"
@@ -107,6 +108,14 @@ test("config hook is a no-op when no anthropic provider exists", async () => {
 
 test("plugin leaves OpenCode system prompts untouched", () => {
   assert.equal(hooks["experimental.chat.system.transform"], undefined)
+})
+
+test("plugin defaults the OpenCode client prompt off for Meridian", () => {
+  const raw = readFileSync(
+    join(fakeHomeDir, ".config", "meridian", "sdk-features.json"),
+    "utf8",
+  )
+  assert.equal(JSON.parse(raw).opencode?.clientSystemPrompt, false)
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Disables Meridian client prompt pass through by default. Closes #137 