### PR TITLE
fix: stop pinning MERIDIAN_WORKDIR at plugin init

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,17 +8,9 @@ import {
 } from "./meridian-config"
 import { getProxyBaseURL, registerCleanup, startProxy } from "./proxy"
 
-export const ClaudeMaxPlugin: Plugin = async ({ client, directory }) => {
+export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
   const log = createLogger(client)
   const agentModes = new Map<string, string>()
-
-  if (
-    directory &&
-    !process.env.MERIDIAN_WORKDIR &&
-    !process.env.CLAUDE_PROXY_WORKDIR
-  ) {
-    process.env.MERIDIAN_WORKDIR = directory
-  }
 
   const meridianConfig = loadMeridianConfig(log)
   const summary = summarizeMeridianConfig(meridianConfig)

--- a/test/unit/plugin-hooks.test.mjs
+++ b/test/unit/plugin-hooks.test.mjs
@@ -194,8 +194,14 @@ test("plugin does not mutate Meridian sdk-features.json", () => {
   )
 })
 
-test("plugin provides Meridian cwd through process env", () => {
-  assert.equal(process.env.MERIDIAN_WORKDIR, fakeHomeDir)
+test("plugin does not pin MERIDIAN_WORKDIR, leaving per-session cwd resolution to Meridian", () => {
+  // Pinning MERIDIAN_WORKDIR at plugin init takes highest precedence in
+  // Meridian's resolveSdkWorkingDirectory and defeats the per-session
+  // adapterCwd extracted from the client. Long-lived hosts (e.g. the
+  // OpenCode desktop app) serve many projects from one process, so the
+  // plugin must not pin a process-wide working directory.
+  assert.equal(process.env.MERIDIAN_WORKDIR, undefined)
+  assert.equal(process.env.CLAUDE_PROXY_WORKDIR, undefined)
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #166

## Problem

The plugin sets `process.env.MERIDIAN_WORKDIR` to its init-time `directory`. That env var has **highest precedence** in Meridian's `resolveSdkWorkingDirectory`, so it defeats the per-session `adapterCwd` Meridian extracts from the client. Long-lived hosts (the OpenCode desktop app in particular) load the plugin once — usually from the home directory — and then serve many projects from the same process, so every session resolves to the launch directory instead of its real project directory. See #166 for full details.

## Solution

Remove the pinning block and let Meridian's own resolution chain do its job: `adapterCwd` per session, falling back to the proxy's `process.cwd()` when the claimed path doesn't exist on the proxy host (Meridian's #381 handling). This is equal or better in every scenario (TUI, desktop multi-project, remote client) — a detailed case analysis is in the issue. Users who need a fixed override can still set `MERIDIAN_WORKDIR` themselves; the plugin now never competes with them.

The now-unused `directory` binding is dropped from the plugin signature.

## Tests

- Replaced the `plugin provides Meridian cwd through process env` unit test with one asserting the plugin does **not** set `MERIDIAN_WORKDIR`/`CLAUDE_PROXY_WORKDIR`, with a comment explaining why pinning is harmful.
- `npm run test:unit`: 72/72 pass.
- Verified the built `dist/index.js` contains no `MERIDIAN_WORKDIR` writes, and manually confirmed the desktop-app scenario resolves per-session after the change.