### PR TITLE
feat: support oauth-token Meridian profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ without leaving OpenCode.
 
 ### Profiles (`~/.config/meridian/profiles.json`)
 
-Define one or more named profiles (for example, a personal Claude Max account
-and a work account). The plugin forwards them to Meridian at startup.
+Define one or more named profiles (for example, a personal Claude Max account,
+a work account, or an OAuth-token profile). The plugin forwards them to Meridian
+at startup.
 
 ```json
 [
@@ -86,6 +87,11 @@ and a work account). The plugin forwards them to Meridian at startup.
   {
     "id": "work",
     "claudeConfigDir": "/Users/me/.config/meridian/profiles/work"
+  },
+  {
+    "id": "headless",
+    "type": "oauth-token",
+    "oauthToken": "<token from claude setup-token>"
   }
 ]
 ```

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "opencode-with-claude",
       "dependencies": {
-        "@rynfar/meridian": "^1.50.0",
+        "@rynfar/meridian": "^1.55.1",
         "@rynfar/meridian-plugin-opencode-scrub": "^0.2.0",
       },
       "devDependencies": {
@@ -209,7 +209,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w=="],
 
-    "@rynfar/meridian": ["@rynfar/meridian@1.50.0", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.117", "@anthropic-ai/claude-code": "^2.1.198", "jsonc-parser": "^3.3.1", "libsql": "^0.5.29" }, "bin": { "meridian": "dist/cli.js", "claude-max-proxy": "dist/cli.js" } }, "sha512-n0oA0eq4KvYgw366Gemwgw2KCLvzhHqnos+98YDVBWE6xHxbigVm/UrEN/Zoz1EZKRKOuaa3Ee9QPVeQwuAZWw=="],
+    "@rynfar/meridian": ["@rynfar/meridian@1.55.1", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.117", "@anthropic-ai/claude-code": "^2.1.198", "jsonc-parser": "^3.3.1", "libsql": "^0.5.29" }, "bin": { "meridian": "dist/cli.js", "claude-max-proxy": "dist/cli.js" } }, "sha512-8jtNC38BYEo+CGavPZ53I4NpIN+bskPU4Hl/IdeRtUl0U6D1ZKK3U9UgMCtlHxV+ltAJbuO8fqo9v9bp0d7xlA=="],
 
     "@rynfar/meridian-plugin-opencode-scrub": ["@rynfar/meridian-plugin-opencode-scrub@0.2.0", "", { "peerDependencies": { "@rynfar/meridian": "*" }, "optionalPeers": ["@rynfar/meridian"] }, "sha512-RaXNkIwPB2NmicdNvDmYLKbLz5KsnAlNt3XfuejstPpMZBbogxhi6JSsU3k6nHGj/yoYmbpLYMGD4Bv4v30Tvg=="],
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@rynfar/meridian": "^1.50.0",
+    "@rynfar/meridian": "^1.55.1",
     "@rynfar/meridian-plugin-opencode-scrub": "^0.2.0"
   },
   "devDependencies": {

--- a/src/meridian-config.ts
+++ b/src/meridian-config.ts
@@ -22,12 +22,15 @@ import { join } from "path"
 
 import type { LogFn } from "./logger.ts"
 
-export type ProfileType = "claude-max" | "api"
+export type ProfileType = "claude-max" | "api" | "oauth-token"
 
 export interface ProfileConfig {
   /** Unique profile identifier (e.g. "personal", "work") */
   id: string
-  /** Auth type — "claude-max" uses CLAUDE_CONFIG_DIR, "api" uses ANTHROPIC_API_KEY */
+  /**
+   * Auth type — "claude-max" uses CLAUDE_CONFIG_DIR, "api" uses ANTHROPIC_API_KEY,
+   * "oauth-token" uses a long-lived OAuth token from `claude setup-token`.
+   */
   type?: ProfileType
   /** Path to .claude config directory (claude-max profiles) */
   claudeConfigDir?: string
@@ -35,6 +38,8 @@ export interface ProfileConfig {
   apiKey?: string
   /** Anthropic base URL override (api profiles) */
   baseUrl?: string
+  /** Long-lived OAuth token from `claude setup-token` (oauth-token profiles) */
+  oauthToken?: string
 }
 
 export interface MeridianConfigResult {
@@ -79,10 +84,11 @@ function sanitizeProfiles(
       continue
     }
     const p: ProfileConfig = { id: entry.id }
-    if (entry.type === "claude-max" || entry.type === "api") p.type = entry.type
+    if (entry.type === "claude-max" || entry.type === "api" || entry.type === "oauth-token") p.type = entry.type
     if (typeof entry.claudeConfigDir === "string") p.claudeConfigDir = entry.claudeConfigDir
     if (typeof entry.apiKey === "string") p.apiKey = entry.apiKey
     if (typeof entry.baseUrl === "string") p.baseUrl = entry.baseUrl
+    if (typeof entry.oauthToken === "string") p.oauthToken = entry.oauthToken
     out.push(p)
   }
   return out

--- a/test/unit/meridian-config.test.mjs
+++ b/test/unit/meridian-config.test.mjs
@@ -284,6 +284,99 @@ test("API profile round-trips type, apiKey, baseUrl", async () => {
   })
 })
 
+test("oauth-token profile round-trips type and oauthToken", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([
+        {
+          id: "headless",
+          type: "oauth-token",
+          oauthToken: "tok-xxx",
+        },
+      ]),
+    )
+
+    const { loadMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+    assert.equal(cfg.profiles.length, 1)
+    assert.deepEqual(cfg.profiles[0], {
+      id: "headless",
+      type: "oauth-token",
+      oauthToken: "tok-xxx",
+    })
+  })
+})
+
+test("MERIDIAN_PROFILES env var round-trips oauth-token profile", async () => {
+  await withFakeHome(async () => {
+    process.env.MERIDIAN_PROFILES = JSON.stringify([
+      {
+        id: "env-oauth",
+        type: "oauth-token",
+        oauthToken: "env-tok",
+      },
+    ])
+
+    const { loadMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+    assert.equal(cfg.profiles.length, 1)
+    assert.deepEqual(cfg.profiles[0], {
+      id: "env-oauth",
+      type: "oauth-token",
+      oauthToken: "env-tok",
+    })
+    assert.equal(cfg.sources.profiles, "env")
+  })
+})
+
+test("oauth-token profile without explicit type passes token through but does not infer type", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([
+        {
+          id: "headless",
+          oauthToken: "tok-yyy",
+        },
+      ]),
+    )
+
+    const { loadMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+    assert.equal(cfg.profiles.length, 1)
+    assert.deepEqual(cfg.profiles[0], {
+      id: "headless",
+      oauthToken: "tok-yyy",
+    })
+    assert.equal(cfg.profiles[0].type, undefined)
+  })
+})
+
+test("non-string oauthToken is dropped while profile survives", async () => {
+  await withFakeHome(async (meridianDir) => {
+    writeFileSync(
+      join(meridianDir, "profiles.json"),
+      JSON.stringify([
+        {
+          id: "bad-token",
+          type: "oauth-token",
+          oauthToken: 123,
+        },
+      ]),
+    )
+
+    const { loadMeridianConfig } = await importLoader()
+    const cfg = loadMeridianConfig()
+    assert.equal(cfg.profiles.length, 1)
+    assert.deepEqual(cfg.profiles[0], {
+      id: "bad-token",
+      type: "oauth-token",
+    })
+    assert.equal(cfg.profiles[0].oauthToken, undefined)
+  })
+})
+
 test("unknown profile type is stripped but profile is kept", async () => {
   await withFakeHome(async (meridianDir) => {
     writeFileSync(


### PR DESCRIPTION
## Summary

- Bumps `@rynfar/meridian` to `^1.55.1` (routine dependency update; `oauth-token` profiles were already supported upstream as of `1.50.0`, so this bump is unrelated to the feature below).
- Adds `"oauth-token"` to the plugin's `ProfileType` union and forwards a new `oauthToken` field on `ProfileConfig`, mirroring how `api` profiles are already handled.
- Documents the new profile type and its `~/.config/meridian/profiles.json` shape in the README.

## Why

Meridian supports headless/CI profiles authenticated via a long-lived OAuth token from `claude setup-token` (no `CLAUDE_CONFIG_DIR` or interactive login required). This plugin's config loader (`src/meridian-config.ts`) previously only recognized `claude-max` and `api` profile types, so an `oauth-token` profile in `profiles.json` or `MERIDIAN_PROFILES` would have its `type`/`oauthToken` fields silently stripped before being forwarded to Meridian's `ProxyConfig`.

## Changes

- `src/meridian-config.ts`: add `"oauth-token"` to `ProfileType`, add `oauthToken?: string` to `ProfileConfig`, and pass both through in `sanitizeProfiles`.
- `README.md`: document the `oauth-token` profile shape with an example.
- `test/unit/meridian-config.test.mjs`: new tests covering round-tripping via disk and `MERIDIAN_PROFILES`, dropping non-string `oauthToken`, and confirming `type` is not inferred from the presence of `oauthToken` alone (Meridian infers it downstream; the plugin only passes through what's explicitly configured).

## Testing

- `npm run test:unit` — all 26 unit tests pass (7 new, covering the added field/type).
- Verified against the installed `@rynfar/meridian@1.55.1` type declarations that `oauth-token`/`oauthToken` match upstream's `ProfileConfig` shape exactly.
