### PR TITLE
fix: bump Meridian 1.60.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "opencode-with-claude",
       "dependencies": {
-        "@rynfar/meridian": "^1.55.1",
+        "@rynfar/meridian": "^1.60.0",
         "@rynfar/meridian-plugin-opencode-scrub": "^0.2.0",
       },
       "devDependencies": {
@@ -209,7 +209,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w=="],
 
-    "@rynfar/meridian": ["@rynfar/meridian@1.55.1", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.117", "@anthropic-ai/claude-code": "^2.1.198", "jsonc-parser": "^3.3.1", "libsql": "^0.5.29" }, "bin": { "meridian": "dist/cli.js", "claude-max-proxy": "dist/cli.js" } }, "sha512-8jtNC38BYEo+CGavPZ53I4NpIN+bskPU4Hl/IdeRtUl0U6D1ZKK3U9UgMCtlHxV+ltAJbuO8fqo9v9bp0d7xlA=="],
+    "@rynfar/meridian": ["@rynfar/meridian@1.60.0", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.117", "@anthropic-ai/claude-code": "^2.1.198", "jsonc-parser": "^3.3.1", "libsql": "^0.5.29" }, "bin": { "meridian": "dist/cli.js", "claude-max-proxy": "dist/cli.js" } }, "sha512-tXDN8ZTl8COM8shqOb0rN7OyFGGoVe8VkYmOVt2L65upYdOd2DcHOIPrGHIqTJs6JSVI3FEYT0OnTEilbxN/NQ=="],
 
     "@rynfar/meridian-plugin-opencode-scrub": ["@rynfar/meridian-plugin-opencode-scrub@0.2.0", "", { "peerDependencies": { "@rynfar/meridian": "*" }, "optionalPeers": ["@rynfar/meridian"] }, "sha512-RaXNkIwPB2NmicdNvDmYLKbLz5KsnAlNt3XfuejstPpMZBbogxhi6JSsU3k6nHGj/yoYmbpLYMGD4Bv4v30Tvg=="],
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@rynfar/meridian": "^1.55.1",
+    "@rynfar/meridian": "^1.60.0",
     "@rynfar/meridian-plugin-opencode-scrub": "^0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Bumps `@rynfar/meridian` from `^1.55.1` to `^1.60.0` (latest published).

`@rynfar/meridian-plugin-opencode-scrub` is already at its latest (`0.2.0`), so it is untouched.

## Notable upstream changes (1.55.1 → 1.60.0)

- **1.60.0** — claude.ai connectors gated behind an opt-in flag; transport metadata no longer treated as a system instruction.
- **1.59.0** — `webFetchPreflight` toggle scoped to the adapter it affects; quieter subprocess outbound traffic.
- **1.58.x** — passthrough defers early stop while a `tool_use` block is still streaming; sanitize fixes (self-closing tags swallowing text, Meridian's own markers on replay); session lineage/compaction fixes; per-tier 1M context overrides; login expiry reported on `/health`.
- **1.57.0** — Claude Opus 5 added and made the canonical opus; image input + incomplete status for `/v1/responses`.
- **1.56.0** — priority profile routing (opt-in); active-profile switches attributed in logs.

### The 1.60.0 connectors behaviour change does not affect this plugin

1.60.0 makes claude.ai connectors require an explicit opt-in for adapters **not** in passthrough mode. `src/proxy.ts` sets `MERIDIAN_PASSTHROUGH` at import time and `opencode` is a passthrough-default adapter, so connectors were already disabled here — no behaviour change for this plugin's users.

## API compatibility

The surface this plugin consumes is unchanged in 1.60.0:

- `startProxyServer({ port, host, silent, profiles, defaultProfile })`
- `ProxyInstance { server, config, close() }`

## Verification

- `bun install` → resolves `@rynfar/meridian@1.60.0`; `bun.lock` updated (CI runs `--frozen-lockfile`, so the lockfile change ships with this PR)
- `bun run build` → exit 0
- `npm run test:unit` → 76/76 pass
