### PR TITLE
feat: surface Meridian version and login expiry at startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,12 @@ import {
   loadMeridianConfig,
   summarizeMeridianConfig,
 } from "./meridian-config"
-import { getProxyBaseURL, registerCleanup, startProxy } from "./proxy"
+import {
+  checkProxyHealth,
+  getProxyBaseURL,
+  registerCleanup,
+  startProxy,
+} from "./proxy"
 
 export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
   const log = createLogger(client)
@@ -28,6 +33,11 @@ export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
   void log("info", `proxy ready at ${baseURL}`)
 
   registerCleanup(proxy)
+
+  // Deliberately not awaited: this only produces log lines, and /health can
+  // take seconds when Meridian's auth cache is cold. Blocking OpenCode's
+  // startup on it would trade real latency for a diagnostic.
+  void checkProxyHealth(proxy.port, log)
 
   return {
     // Set the base URL for the Anthropic provider

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,4 +1,7 @@
+import { existsSync, readFileSync } from "fs"
+import { createRequire } from "module"
 import type { AddressInfo } from "net"
+import { dirname, join } from "path"
 import { classifyProxyLog, type LogFn } from "./logger.ts"
 import type { ProfileConfig } from "./meridian-config.ts"
 import { startProxyServer } from "@rynfar/meridian"
@@ -30,6 +33,48 @@ export interface ProxyHandle {
 
 const DEFAULT_PORT = 3456
 const DEFAULT_HOST = "127.0.0.1"
+
+const MERIDIAN_PACKAGE = "@rynfar/meridian"
+
+/**
+ * Read the installed Meridian version so it can be handed to
+ * `startProxyServer({ version })`.
+ *
+ * Meridian falls back to the literal string `"unknown"` on /health unless the
+ * host passes this in: its CLI reads its own package.json, but a library
+ * consumer such as this plugin has to do the same. Without it, /health, the
+ * dashboard, and any external monitor all report `"unknown"`.
+ *
+ * The manifest cannot be resolved as a subpath — Meridian's `exports` map only
+ * declares `"."`, so `require.resolve("@rynfar/meridian/package.json")` throws
+ * ERR_PACKAGE_PATH_NOT_EXPORTED. Resolve the entry point instead and walk up to
+ * the owning package root. Returns undefined if anything is unexpected, which
+ * simply leaves Meridian's own fallback in place.
+ */
+export function resolveMeridianVersion(): string | undefined {
+  try {
+    let dir = dirname(createRequire(import.meta.url).resolve(MERIDIAN_PACKAGE))
+
+    for (let depth = 0; depth < 5; depth++) {
+      const manifest = join(dir, "package.json")
+      if (existsSync(manifest)) {
+        const parsed = JSON.parse(readFileSync(manifest, "utf8")) as {
+          name?: unknown
+          version?: unknown
+        }
+        if (parsed.name === MERIDIAN_PACKAGE && typeof parsed.version === "string") {
+          return parsed.version
+        }
+      }
+      const parent = dirname(dir)
+      if (parent === dir) break
+      dir = parent
+    }
+    return undefined
+  } catch {
+    return undefined
+  }
+}
 
 function formatHostForUrl(host: string): string {
   return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host
@@ -64,6 +109,7 @@ export function getProxyBaseURL(
 export async function startProxy(opts: StartProxyOptions): Promise<ProxyHandle> {
   const { port = DEFAULT_PORT, log, profiles, defaultProfile } = opts
   const host = getProxyHost()
+  const version = resolveMeridianVersion()
 
   const origError = console.error
   console.error = (...args: unknown[]) => {
@@ -84,6 +130,7 @@ export async function startProxy(opts: StartProxyOptions): Promise<ProxyHandle> 
           silent: true,
           profiles,
           defaultProfile,
+          version,
         }).then((proxy) => {
           // EADDRINUSE is emitted asynchronously on the server – the
           // promise from startProxyServer resolves before the error
@@ -157,6 +204,47 @@ export async function startProxy(opts: StartProxyOptions): Promise<ProxyHandle> 
 export interface HealthResult {
   ok: boolean
   message?: string
+  /** Meridian version behind the proxy. Absent on releases that omit it. */
+  version?: string
+  /** Days until the Claude login itself expires, when Meridian reports it. */
+  daysUntilRenewal?: number
+  /** True when Meridian flags the login as needing renewal soon. */
+  renewalRequiredSoon?: boolean
+}
+
+type RenewalFields = Pick<HealthResult, "daysUntilRenewal" | "renewalRequiredSoon">
+
+/**
+ * Read the login-renewal fields Meridian added to /health in 1.58.0. Older
+ * releases omit them, so every field is optional and an absent field means
+ * "unknown" — never "expiring".
+ */
+function readRenewal(auth: unknown): RenewalFields {
+  if (typeof auth !== "object" || auth === null) return {}
+  const record = auth as Record<string, unknown>
+  const out: RenewalFields = {}
+  if (
+    typeof record.daysUntilRenewal === "number" &&
+    Number.isFinite(record.daysUntilRenewal)
+  ) {
+    out.daysUntilRenewal = record.daysUntilRenewal
+  }
+  if (typeof record.renewalRequiredSoon === "boolean") {
+    out.renewalRequiredSoon = record.renewalRequiredSoon
+  }
+  return out
+}
+
+/**
+ * Phrase the remaining login window. Meridian ceils the day count to match
+ * Claude Code's own "your login expires in N days" warning, so the number
+ * here reads identically to the one the terminal prints.
+ */
+function describeRenewalWindow(days: number | undefined): string {
+  if (days === undefined) return "soon"
+  if (days <= 0) return "today"
+  if (days === 1) return "in 1 day"
+  return `in ${days} days`
 }
 
 export async function checkProxyHealth(
@@ -168,8 +256,28 @@ export async function checkProxyHealth(
       signal: AbortSignal.timeout(5_000),
     })
     const body = await res.json() as Record<string, unknown>
+    // Meridian answers with the literal string "unknown" when it has no
+    // version to report, which carries no information worth logging.
+    const reported = body.version
+    const version =
+      typeof reported === "string" && reported !== "unknown" ? reported : undefined
+    const renewal = readRenewal(body.auth)
 
-    if (body.status === "healthy") return { ok: true }
+    // The plugin embeds Meridian as a library, so nothing else tells a user
+    // which build is actually running when they file a bug report.
+    if (version) void log?.("info", `[claude-max] meridian ${version}`)
+
+    // A dead refresh token is the one auth failure nothing automated
+    // recovers from, and it is knowable days ahead. OpenCode users never see
+    // Meridian's dashboard, so this is their only notice.
+    if (renewal.renewalRequiredSoon) {
+      void log?.(
+        "warn",
+        `[claude-max] Claude login expires ${describeRenewalWindow(renewal.daysUntilRenewal)}. Run 'claude login' to renew — the proxy cannot refresh it for you.`
+      )
+    }
+
+    if (body.status === "healthy") return { ok: true, version, ...renewal }
 
     if (body.status === "degraded") {
       const detail =
@@ -180,7 +288,7 @@ export async function checkProxyHealth(
         "warn",
         `[claude-max] ${detail}. Requests may still work — if they hang, try running 'claude login' in your terminal.`
       )
-      return { ok: true, message: detail }
+      return { ok: true, message: detail, version, ...renewal }
     }
 
     // "unhealthy" or unexpected status
@@ -190,7 +298,7 @@ export async function checkProxyHealth(
         : `Proxy health check returned status: ${body.status ?? res.status}`
 
     void log?.( "error", `[claude-max] ${detail}`)
-    return { ok: false, message: detail }
+    return { ok: false, message: detail, version, ...renewal }
   } catch (err) {
     const msg =
       err instanceof Error ? err.message : String(err)

--- a/test/unit/proxy-health.test.mjs
+++ b/test/unit/proxy-health.test.mjs
@@ -1,0 +1,262 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { createServer } from "node:http"
+import { mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { tmpdir } from "node:os"
+import { fileURLToPath } from "node:url"
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..")
+
+function installedMeridianVersion() {
+  const manifest = join(REPO_ROOT, "node_modules", "@rynfar", "meridian", "package.json")
+  return JSON.parse(readFileSync(manifest, "utf8")).version
+}
+
+// Coverage for the metadata checkProxyHealth reads off Meridian's /health:
+// the embedded version and the login-renewal fields Meridian added in 1.58.0.
+// Each case serves a crafted payload from a stub server, so the assertions
+// depend on neither a real Claude login nor the installed Meridian version —
+// including the pre-1.58.0 payload shape, which no installed version emits.
+
+async function freshImport() {
+  return await import(`../../src/proxy.ts?t=${Date.now()}${Math.random()}`)
+}
+
+async function withStubHealth({ payload, status = 200 }, assertions) {
+  const server = createServer((req, res) => {
+    if (!req.url?.startsWith("/health")) {
+      res.writeHead(404).end()
+      return
+    }
+    res.writeHead(status, { "content-type": "application/json" })
+    res.end(JSON.stringify(payload))
+  })
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+
+  // The helper resolves the URL through getProxyHost(), so a host override in
+  // the developer's shell would point the check away from the stub.
+  const prev = {
+    MERIDIAN_HOST: process.env.MERIDIAN_HOST,
+    CLAUDE_PROXY_HOST: process.env.CLAUDE_PROXY_HOST,
+  }
+  delete process.env.MERIDIAN_HOST
+  delete process.env.CLAUDE_PROXY_HOST
+
+  const logs = []
+  try {
+    const { checkProxyHealth } = await freshImport()
+    const result = await checkProxyHealth(server.address().port, async (level, message) => {
+      logs.push({ level, message })
+    })
+    await assertions({ result, logs })
+  } finally {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+    await new Promise((resolve) => server.close(resolve))
+  }
+}
+
+function findLog(logs, level, substring) {
+  return logs.find((l) => l.level === level && l.message.includes(substring))
+}
+
+const healthy = (auth = { loggedIn: true }, extra = {}) => ({
+  status: "healthy",
+  version: "1.60.0",
+  auth,
+  mode: "passthrough",
+  ...extra,
+})
+
+test("healthy: logs the Meridian version and returns it", async () => {
+  await withStubHealth({ payload: healthy() }, ({ result, logs }) => {
+    assert.equal(result.ok, true)
+    assert.equal(result.version, "1.60.0")
+    assert.ok(findLog(logs, "info", "meridian 1.60.0"))
+  })
+})
+
+test("healthy: Meridian's \"unknown\" placeholder is not reported as a version", async () => {
+  await withStubHealth({ payload: healthy({ loggedIn: true }, { version: "unknown" }) }, ({ result, logs }) => {
+    assert.equal(result.version, undefined)
+    assert.equal(findLog(logs, "info", "meridian "), undefined)
+  })
+})
+
+test("healthy: a payload without a version logs nothing about the version", async () => {
+  const payload = healthy()
+  delete payload.version
+
+  await withStubHealth({ payload }, ({ result, logs }) => {
+    assert.equal(result.ok, true)
+    assert.equal(result.version, undefined)
+    assert.equal(findLog(logs, "info", "meridian "), undefined)
+  })
+})
+
+test("renewalRequiredSoon: warns with the day count and the fix", async () => {
+  const payload = healthy({
+    loggedIn: true,
+    daysUntilRenewal: 3,
+    renewalRequiredSoon: true,
+  })
+
+  await withStubHealth({ payload }, ({ result, logs }) => {
+    assert.equal(result.ok, true)
+    assert.equal(result.daysUntilRenewal, 3)
+    assert.equal(result.renewalRequiredSoon, true)
+
+    const warning = findLog(logs, "warn", "expires in 3 days")
+    assert.ok(warning, "expected a warning naming the remaining days")
+    assert.ok(warning.message.includes("claude login"))
+  })
+})
+
+test("renewalRequiredSoon: one day reads as singular", async () => {
+  const payload = healthy({
+    loggedIn: true,
+    daysUntilRenewal: 1,
+    renewalRequiredSoon: true,
+  })
+
+  await withStubHealth({ payload }, ({ logs }) => {
+    assert.ok(findLog(logs, "warn", "expires in 1 day."))
+  })
+})
+
+test("renewalRequiredSoon: a non-positive day count reads as today", async () => {
+  const payload = healthy({
+    loggedIn: true,
+    daysUntilRenewal: 0,
+    renewalRequiredSoon: true,
+  })
+
+  await withStubHealth({ payload }, ({ logs }) => {
+    assert.ok(findLog(logs, "warn", "expires today"))
+  })
+})
+
+test("renewalRequiredSoon false: no warning, flag still reported", async () => {
+  const payload = healthy({
+    loggedIn: true,
+    daysUntilRenewal: 20,
+    renewalRequiredSoon: false,
+  })
+
+  await withStubHealth({ payload }, ({ result, logs }) => {
+    assert.equal(result.renewalRequiredSoon, false)
+    assert.equal(result.daysUntilRenewal, 20)
+    assert.equal(
+      logs.find((l) => l.level === "warn"),
+      undefined,
+    )
+  })
+})
+
+test("Meridian without the renewal fields: no warning, nothing invented", async () => {
+  const payload = healthy({
+    loggedIn: true,
+    email: "user@example.com",
+    subscriptionType: "max",
+  })
+
+  await withStubHealth({ payload }, ({ result, logs }) => {
+    assert.equal(result.ok, true)
+    assert.equal(result.renewalRequiredSoon, undefined)
+    assert.equal(result.daysUntilRenewal, undefined)
+    assert.equal(
+      logs.find((l) => l.level === "warn"),
+      undefined,
+    )
+  })
+})
+
+test("a malformed auth field is ignored rather than trusted", async () => {
+  const payload = healthy({
+    loggedIn: true,
+    daysUntilRenewal: "soon",
+    renewalRequiredSoon: "yes",
+  })
+
+  await withStubHealth({ payload }, ({ result, logs }) => {
+    assert.equal(result.daysUntilRenewal, undefined)
+    assert.equal(result.renewalRequiredSoon, undefined)
+    assert.equal(
+      logs.find((l) => l.level === "warn"),
+      undefined,
+    )
+  })
+})
+
+test("degraded: still reports the version and stays usable", async () => {
+  const payload = {
+    status: "degraded",
+    version: "1.60.0",
+    error: "Could not verify auth status",
+    mode: "passthrough",
+  }
+
+  await withStubHealth({ payload }, ({ result, logs }) => {
+    assert.equal(result.ok, true)
+    assert.equal(result.version, "1.60.0")
+    assert.equal(result.message, "Could not verify auth status")
+    assert.ok(findLog(logs, "info", "meridian 1.60.0"))
+    assert.ok(findLog(logs, "warn", "Could not verify auth status"))
+  })
+})
+
+test("unhealthy: not ok, version still reported", async () => {
+  const payload = {
+    status: "unhealthy",
+    version: "1.60.0",
+    error: "Not logged in. Run: claude login",
+    auth: { loggedIn: false },
+  }
+
+  await withStubHealth({ payload, status: 503 }, ({ result, logs }) => {
+    assert.equal(result.ok, false)
+    assert.equal(result.version, "1.60.0")
+    assert.ok(findLog(logs, "error", "Not logged in"))
+  })
+})
+
+test("resolveMeridianVersion: reports the installed package's version", async () => {
+  const { resolveMeridianVersion } = await freshImport()
+  assert.equal(resolveMeridianVersion(), installedMeridianVersion())
+})
+
+// Meridian only reports a version on /health if the embedding host supplies
+// one, so assert against a live proxy rather than a stub: this is the wiring
+// that decides whether real users see a version or "unknown". Only the version
+// is asserted — auth status varies by machine, and every /health branch carries
+// the field.
+test("startProxy: a live proxy reports the real version on /health", async () => {
+  const home = mkdtempSync(join(tmpdir(), "owc-health-"))
+  mkdirSync(join(home, ".config", "meridian"), { recursive: true })
+  const prev = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE }
+  process.env.HOME = home
+  process.env.USERPROFILE = home
+
+  try {
+    const { startProxy, getProxyBaseURL } = await freshImport()
+    const proxy = await startProxy({ port: 0, log: undefined })
+    try {
+      const res = await fetch(`${getProxyBaseURL(proxy.port)}/health`, {
+        signal: AbortSignal.timeout(30_000),
+      })
+      const body = await res.json()
+      assert.equal(body.version, installedMeridianVersion())
+    } finally {
+      await proxy.close()
+    }
+  } finally {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+    rmSync(home, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## What

`checkProxyHealth()` is exported from `src/proxy.ts` but has **no caller** anywhere in `src/` or `test/` — Meridian's `/health` payload never reached the plugin log. This calls it once after the proxy starts and surfaces the two things users cannot learn any other way.

### 1. Login expiry

Meridian 1.58.0 added `auth.daysUntilRenewal` / `auth.renewalRequiredSoon` to `/health`. When the refresh token dies, Meridian's background scheduler can no longer keep the proxy alive and someone has to run `claude login` interactively — it is the one auth failure nothing automated recovers from, and it is knowable days in advance.

OpenCode users never open Meridian's dashboard, so this warning is their only notice:

```
[claude-max] Claude login expires in 3 days. Run 'claude login' to renew — the proxy cannot refresh it for you.
```

Parsing is deliberately defensive — an absent field means *unknown*, never *expiring*, so Meridian releases without these fields produce no warning instead of a false one. Non-boolean/non-numeric values are ignored rather than trusted.

### 2. Meridian version — `/health` was reporting `"unknown"` for every user

Meridian resolves the version as `finalConfig.version ?? "unknown"`. Its CLI passes its own `package.json` version in; a **library** consumer has to do the same, and this plugin never did. Verified against a real proxy before the change:

```json
{ "status": "healthy", "version": "unknown", "mode": "passthrough", ... }
```

That placeholder is not just cosmetic in our log — it is what the dashboard and any external `/health` monitor saw too. So the fix is to pass the version through rather than paper over it in the log; `ProxyConfig.version` has existed since at least 1.55.1 ("Package version, exposed via /health endpoint"). After:

```json
{ "status": "healthy", "version": "1.55.1", "mode": "passthrough", ... }
```

```
[claude-max] meridian 1.55.1
```

Reading the version needs a small workaround: Meridian's `exports` map only declares `"."`, so `require.resolve("@rynfar/meridian/package.json")` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. `resolveMeridianVersion()` resolves the entry point and walks up to the owning package root instead, returning `undefined` on anything unexpected — which just restores Meridian's own fallback, so it cannot break startup.

The literal `"unknown"` is also treated as absent when reading `/health`, so an older or oddly-configured proxy never logs `meridian unknown`.

## Notes

- **Not awaited.** `void checkProxyHealth(...)` is intentional and commented: it only produces log lines, and `/health` can take seconds when Meridian's auth cache is cold. Awaiting it would add up to 5s to OpenCode's startup for a diagnostic.
- **Version floor.** The renewal fields need Meridian ≥ 1.58.0. `^1.55.1` already resolves there on a fresh install, and the parsing degrades silently on older ones. #180 raises the floor explicitly; the two PRs are independent and don't conflict.
- No README change — the warning states the remedy inline.

## Verification

- `bun run build` (tsup + tsc) → exit 0
- `npm run test:unit` → **89/89 pass**: 76 on `main` before this change, 13 added in `test/unit/proxy-health.test.mjs`
- New coverage: version reported/absent/`"unknown"`; renewal warning wording at 3 days / 1 day / 0 days; `renewalRequiredSoon: false`; pre-1.58.0 payload shape; malformed `auth` values; degraded and unhealthy branches; `resolveMeridianVersion()` against the installed manifest
- One test asserts against a **live proxy**, not a stub, since the version wiring is exactly what decides whether users see a real version or `"unknown"`
- Also exercised manually against a real proxy on this machine: `/health` went from `"version": "unknown"` to `"version": "1.55.1"`, and the log line appeared as shown above
