### PR TITLE
feat: mark human request turns

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,14 @@ import {
   startProxy,
 } from "./proxy"
 
+const MAX_HUMAN_MESSAGES = 4096
 export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
   const log = createLogger(client)
   const agentModes = new Map<string, string>()
+  const humanMessages = new Map<string, true>()
+
+  const messageKey = (sessionID: string, messageID: string) =>
+    `${sessionID}\u0000${messageID}`
 
   const meridianConfig = loadMeridianConfig(log)
   const summary = summarizeMeridianConfig(meridianConfig)
@@ -49,7 +54,18 @@ export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
 
       const anthropic = input.provider?.anthropic
       if (!anthropic) return
-      ;(anthropic.options ??= {}).baseURL = baseURL
+      if (!anthropic.options) anthropic.options = {}
+      anthropic.options.baseURL = baseURL
+    },
+
+    async "chat.message"(input, output) {
+      const key = messageKey(input.sessionID, output.message.id)
+      humanMessages.delete(key)
+      humanMessages.set(key, true)
+      if (humanMessages.size > MAX_HUMAN_MESSAGES) {
+        const oldest = humanMessages.keys().next().value
+        if (oldest !== undefined) humanMessages.delete(oldest)
+      }
     },
 
     // Keep user context, but scrub OpenCode fingerprints before Meridian passthrough.
@@ -84,6 +100,11 @@ export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
 
       output.headers["x-opencode-session"] = incoming.sessionID
       output.headers["x-opencode-request"] = incoming.message.id
+      output.headers["x-opencode-request-kind"] = humanMessages.has(
+        messageKey(incoming.sessionID, incoming.message.id),
+      )
+        ? "human"
+        : "synthetic"
       output.headers["x-opencode-agent-mode"] = agentMode
       output.headers["x-opencode-agent-name"] = agentName
     },

--- a/test/unit/plugin-hooks.test.mjs
+++ b/test/unit/plugin-hooks.test.mjs
@@ -208,6 +208,101 @@ test("plugin does not pin MERIDIAN_WORKDIR, leaving per-session cwd resolution t
 // chat.headers — strip anthropic-beta, add OpenCode/Meridian headers
 // ---------------------------------------------------------------------------
 
+test("chat.message marks the observed message ID as human for chat.headers", async () => {
+  const messageId = "msg-human"
+  await hooks["chat.message"](
+    { sessionID: "sess-123" },
+    { message: { id: messageId } },
+  )
+
+  const output = { headers: {} }
+  await hooks["chat.headers"](
+    {
+      sessionID: "sess-123",
+      model: { providerID: "anthropic" },
+      message: { id: messageId },
+    },
+    output,
+  )
+
+  assert.equal(output.headers["x-opencode-request-kind"], "human")
+})
+
+test("chat.headers keeps an observed message ID human across repeated calls in the same session", async () => {
+  const messageId = "msg-repeated-human"
+  const sessionID = "sess-123"
+  await hooks["chat.message"](
+    { sessionID },
+    { message: { id: messageId } },
+  )
+
+  for (const _ of [0, 1]) {
+    const output = { headers: {} }
+    await hooks["chat.headers"](
+      {
+        sessionID,
+        model: { providerID: "anthropic" },
+        message: { id: messageId },
+      },
+      output,
+    )
+    assert.equal(output.headers["x-opencode-request-kind"], "human")
+  }
+})
+
+test("chat.headers marks the same message ID in another session as synthetic", async () => {
+  const messageId = "msg-session-scoped"
+  await hooks["chat.message"](
+    { sessionID: "sess-human" },
+    { message: { id: messageId } },
+  )
+
+  const output = { headers: {} }
+  await hooks["chat.headers"](
+    {
+      sessionID: "sess-other",
+      model: { providerID: "anthropic" },
+      message: { id: messageId },
+    },
+    output,
+  )
+
+  assert.equal(output.headers["x-opencode-request-kind"], "synthetic")
+})
+
+test("chat.headers marks an unobserved message ID as synthetic", async () => {
+  const output = { headers: {} }
+  await hooks["chat.headers"](
+    {
+      sessionID: "sess-123",
+      model: { providerID: "anthropic" },
+      message: { id: "msg-unobserved-synthetic" },
+    },
+    output,
+  )
+
+  assert.equal(output.headers["x-opencode-request-kind"], "synthetic")
+})
+
+test("turn-origin metadata does not change non-anthropic chat.headers behavior", async () => {
+  await hooks["chat.message"](
+    { sessionID: "sess-123" },
+    { message: { id: "msg-non-anthropic" } },
+  )
+  const output = { headers: { "anthropic-beta": "still-here" } }
+
+  await hooks["chat.headers"](
+    {
+      sessionID: "sess-123",
+      model: { providerID: "openai" },
+      message: { id: "msg-non-anthropic" },
+    },
+    output,
+  )
+
+  assert.deepEqual(output.headers, { "anthropic-beta": "still-here" })
+})
+
 test("chat.headers strips anthropic-beta and adds session + request IDs", async () => {
   const output = { headers: { "anthropic-beta": "some-flag", keep: "me" } }
   await hooks["chat.headers"](


### PR DESCRIPTION
## Summary

- observe OpenCode `chat.message` events and retain a bounded session/message origin map
- add `x-opencode-request-kind: human` for observed user messages
- mark unobserved synthetic/title/helper requests as `synthetic`
- keep origin tracking scoped by session and leave non-Anthropic headers unchanged
- preserve upstream behavior that strips Anthropic beta flags before Meridian passthrough

## Testing

- `./build.sh` from the four-repo `local/dev-stack` workspace: passed
- `npm run test:unit`: 94 passed, 0 failed
- `npm run build`: passed
- `git diff --check`: passed

## Integration note

These headers are consumed by rynfar/meridian#834 to implement the opt-in `next-user-turn` priority failback policy. Existing Meridian behavior remains compatible when the header is absent.