### PR TITLE
chore: bump Meridian to 1.62.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "opencode-with-claude",
       "dependencies": {
-        "@rynfar/meridian": "^1.61.0",
+        "@rynfar/meridian": "^1.62.6",
         "@rynfar/meridian-plugin-opencode-scrub": "^0.2.0",
       },
       "devDependencies": {
@@ -209,7 +209,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w=="],
 
-    "@rynfar/meridian": ["@rynfar/meridian@1.61.0", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.117", "@anthropic-ai/claude-code": "^2.1.198", "jsonc-parser": "^3.3.1", "libsql": "^0.5.29" }, "bin": { "meridian": "dist/cli.js", "claude-max-proxy": "dist/cli.js" } }, "sha512-s0pL2I/MavrlyNTuAEVP2SVyiwKiscBauc4yLTHQgZNqGMFHWiRwvsx7Mf7wbnpypKH/U1MJhlfChFb4oa5yZg=="],
+    "@rynfar/meridian": ["@rynfar/meridian@1.62.6", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.117", "@anthropic-ai/claude-code": "^2.1.198", "jsonc-parser": "^3.3.1", "libsql": "^0.5.29" }, "bin": { "meridian": "dist/cli.js", "claude-max-proxy": "dist/cli.js" } }, "sha512-lLzId3rt38iai3X9SHEoGJPJHEGx/GB6O42upB66ls+Nnr3TMGtNk6iIGPq0tF4ljEHdkemc+bGXo6KzYcBXoQ=="],
 
     "@rynfar/meridian-plugin-opencode-scrub": ["@rynfar/meridian-plugin-opencode-scrub@0.2.0", "", { "peerDependencies": { "@rynfar/meridian": "*" }, "optionalPeers": ["@rynfar/meridian"] }, "sha512-RaXNkIwPB2NmicdNvDmYLKbLz5KsnAlNt3XfuejstPpMZBbogxhi6JSsU3k6nHGj/yoYmbpLYMGD4Bv4v30Tvg=="],
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@rynfar/meridian": "^1.61.0",
+    "@rynfar/meridian": "^1.62.6",
     "@rynfar/meridian-plugin-opencode-scrub": "^0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps `@rynfar/meridian` from `^1.61.0` to `^1.62.6` and updates the lockfile.

## What changed in Meridian

Notable fixes between `1.61.0` and `1.62.6`:

- **1.62.6** — OpenCode's internal `title`/`summary`/`compaction` agents now get their own session key, preventing them from colliding with the user's real turn and causing `session_turn_conflict` errors.
- **1.62.5** — Native Task subagents are routed to base model tiers instead of inheriting the parent's extended-context variant.
- **1.62.2** — Graceful shutdown: `ProxyInstance.close()` now drains in-flight requests before closing the port.
- **1.62.2** — SDK/session concurrency is coordinated through a shared process-wide semaphore.

All of the above are handled automatically by this plugin:
- The plugin already sends `x-opencode-agent-mode` and `x-opencode-agent-name`, which Meridian uses for session scoping and subagent tier selection.
- The plugin already calls `proxy.close()` on exit, so it gets graceful shutdown for free.

## Verification

- `npm run build` passes.
- `npm run test:unit` passes: **89/89 tests**.

No plugin source code changes are required.