### PR TITLE
fix: pin Meridian runtime dependencies to exact versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "opencode-with-claude",
       "dependencies": {
-        "@rynfar/meridian": "^1.62.6",
-        "@rynfar/meridian-plugin-opencode-scrub": "^0.2.0",
+        "@rynfar/meridian": "1.62.6",
+        "@rynfar/meridian-plugin-opencode-scrub": "0.2.0",
       },
       "devDependencies": {
         "@opencode-ai/plugin": "^1.18.3",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@rynfar/meridian": "^1.62.6",
-    "@rynfar/meridian-plugin-opencode-scrub": "^0.2.0"
+    "@rynfar/meridian": "1.62.6",
+    "@rynfar/meridian-plugin-opencode-scrub": "0.2.0"
   },
   "devDependencies": {
     "@opencode-ai/plugin": "^1.18.3",


### PR DESCRIPTION
## Problem

`package.json` declared Meridian dependencies with caret ranges (`^1.62.6`), and the published npm package only ships `dist/` — no lockfile. This means when a user installs an older plugin version (e.g. `1.8.0` which declared `^1.60.0`), npm resolves to the newest compatible Meridian version available at install time rather than the version that plugin release was built against. In practice, `opencode-with-claude@1.8.0` ends up running Meridian `1.62.7`, so downgrading the plugin does not downgrade Meridian.

## Change

Pin the runtime Meridian dependencies to exact versions:

- `@rynfar/meridian`: `^1.62.6` → `1.62.6`
- `@rynfar/meridian-plugin-opencode-scrub`: `^0.2.0` → `0.2.0`

Also update `bun.lock` to match.

## Why this fixes it

npm installs the exact version declared in `dependencies` when no range prefix is present. Because the published package's `package.json` is what consumers resolve against, each release now carries the exact Meridian version it was tested with. Future bumps (manual or via Dependabot) will update the literal version string, and those strings will be reproducible when installing older plugin versions.

## Verification

- `bun install`
- `bun run build`
- `bun run test:unit` — 94 tests pass

Closes the issue where plugin version `1.8.0` was observed running Meridian `1.62.7`.