### PR TITLE
feat: distribute the plugin with Homebrew

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,3 +42,27 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}
+
+      # Keep the Homebrew formula in this repo pointing at the release that was
+      # just published, so `brew upgrade` picks it up. Pushes made with the
+      # default GITHUB_TOKEN do not trigger workflows, so this cannot loop.
+      - name: Update Homebrew formula
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          VERSION="$(node -p "require('./package.json').version")"
+          scripts/update-homebrew-formula.sh "$VERSION"
+          git add Formula/opencode-with-claude.rb
+          if git diff --cached --quiet; then
+            echo "Formula already up to date"
+            exit 0
+          fi
+          git commit -m "chore: update Homebrew formula to v$VERSION"
+          for attempt in 1 2 3; do
+            git push origin HEAD:main && exit 0
+            echo "push failed (attempt $attempt), rebasing onto latest main..."
+            git fetch origin main
+            git rebase origin/main
+          done
+          exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  # Manual run: re-sync the Homebrew tap from the formula on main without
+  # cutting a release (for example, right after creating the tap repo).
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -12,8 +15,11 @@ permissions:
 
 jobs:
   release-please:
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
@@ -43,9 +49,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}
 
-      # Keep the Homebrew formula in this repo pointing at the release that was
-      # just published, so `brew upgrade` picks it up. Pushes made with the
-      # default GITHUB_TOKEN do not trigger workflows, so this cannot loop.
+      # Keep Formula/opencode-with-claude.rb pointing at the release that was
+      # just published. Pushes made with the default GITHUB_TOKEN do not
+      # trigger workflows, so this cannot loop.
       - name: Update Homebrew formula
         if: ${{ steps.release.outputs.release_created }}
         run: |
@@ -66,3 +72,42 @@ jobs:
             git rebase origin/main
           done
           exit 1
+
+  # Mirror the formula into the dedicated tap (brew tap ianjwhite99/tap).
+  # Needs a HOMEBREW_TAP_TOKEN secret: a fine-grained PAT with "Contents:
+  # read and write" on ianjwhite99/homebrew-tap. Skips with a warning if unset.
+  homebrew-tap:
+    needs: release-please
+    if: ${{ !cancelled() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      TAP_REPO: ianjwhite99/homebrew-tap
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+    steps:
+      # Always read main, so a release run sees the formula bump committed
+      # by the previous job rather than the pre-release checkout.
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Publish formula to Homebrew tap
+        run: |
+          if [ -z "$HOMEBREW_TAP_TOKEN" ]; then
+            echo "::warning::HOMEBREW_TAP_TOKEN is not set; skipping Homebrew tap sync"
+            exit 0
+          fi
+          VERSION="$(node -p "require('./package.json').version")"
+          git clone --depth 1 "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${TAP_REPO}.git" tap
+          mkdir -p tap/Formula
+          cp Formula/opencode-with-claude.rb tap/Formula/opencode-with-claude.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/opencode-with-claude.rb
+          if git diff --cached --quiet; then
+            echo "Tap already up to date"
+            exit 0
+          fi
+          git commit -m "opencode-with-claude: update to v$VERSION"
+          git push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,11 +85,11 @@ jobs:
       TAP_REPO: ianjwhite99/homebrew-tap
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
     steps:
-      # Always read main, so a release run sees the formula bump committed
-      # by the previous job rather than the pre-release checkout.
+      # Check out the branch tip rather than the triggering commit, so a
+      # release run sees the formula bump committed by the previous job.
       - uses: actions/checkout@v7
         with:
-          ref: main
+          ref: ${{ github.ref_name }}
 
       - name: Publish formula to Homebrew tap
         run: |

--- a/Formula/opencode-with-claude.rb
+++ b/Formula/opencode-with-claude.rb
@@ -2,7 +2,8 @@
 #
 # The `url` and `sha256` lines are rewritten automatically by
 # scripts/update-homebrew-formula.sh from the Release workflow after each
-# npm publish. Do not edit them by hand.
+# npm publish, then mirrored to the ianjwhite99/homebrew-tap repository
+# (brew tap ianjwhite99/tap). Do not edit them by hand.
 class OpencodeWithClaude < Formula
   desc "OpenCode plugin to use your Claude Max subscription via Meridian proxy"
   homepage "https://github.com/ianjwhite99/opencode-with-claude"

--- a/Formula/opencode-with-claude.rb
+++ b/Formula/opencode-with-claude.rb
@@ -1,0 +1,66 @@
+# Homebrew formula for opencode-with-claude.
+#
+# The `url` and `sha256` lines are rewritten automatically by
+# scripts/update-homebrew-formula.sh from the Release workflow after each
+# npm publish. Do not edit them by hand.
+class OpencodeWithClaude < Formula
+  desc "OpenCode plugin to use your Claude Max subscription via Meridian proxy"
+  homepage "https://github.com/ianjwhite99/opencode-with-claude"
+  url "https://registry.npmjs.org/opencode-with-claude/-/opencode-with-claude-1.9.5.tgz"
+  sha256 "17b2f4932c73746397b6213248880241b99711b12b474d9668a95a52c47626b4"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    # Installs the published package (prebuilt dist/) and its runtime
+    # dependencies (Meridian, the Claude Agent SDK, ...) into
+    # libexec/lib/node_modules/opencode-with-claude. The package ships no
+    # executable, so nothing is linked into bin.
+    system "npm", "install", *std_npm_args
+  end
+
+  # Version-stable path to the plugin entry point. `opt_libexec` survives
+  # `brew upgrade`, so users only ever configure this path once.
+  def plugin_entry
+    opt_libexec/"lib/node_modules/opencode-with-claude/dist/index.js"
+  end
+
+  def caveats
+    <<~EOS
+      Add the plugin to your OpenCode config (~/.config/opencode/opencode.json):
+
+        {
+          "$schema": "https://opencode.ai/config.json",
+          "plugin": ["file://#{plugin_entry}"],
+          "provider": {
+            "anthropic": {
+              "options": {
+                "baseURL": "http://127.0.0.1:3456",
+                "apiKey": "dummy"
+              }
+            }
+          }
+        }
+
+      The plugin needs the Claude Code CLI and an authenticated Claude Max
+      session:
+
+        brew install --cask claude-code   # or: npm install -g @anthropic-ai/claude-code
+        claude auth login
+
+      `brew upgrade opencode-with-claude` updates the plugin in place; the
+      path above does not change between versions.
+    EOS
+  end
+
+  test do
+    entry = libexec/"lib/node_modules/opencode-with-claude/dist/index.js"
+    assert_path_exists entry
+
+    # Importing the module must succeed and expose the plugin factory without
+    # starting the proxy (that only happens when OpenCode calls the factory).
+    script = "import('#{entry}').then(m => console.log(Object.keys(m).join(',')))"
+    assert_match "ClaudeMaxPlugin", shell_output("node -e \"#{script}\"")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ Or with [Homebrew](https://brew.sh) (macOS/Linux), which keeps the plugin
 updated through `brew upgrade` instead of `npm update -g`:
 
 ```bash
-brew tap ianjwhite99/opencode-with-claude https://github.com/ianjwhite99/opencode-with-claude
-brew install opencode-with-claude
+brew install ianjwhite99/tap/opencode-with-claude
 ```
 
 **2. Authenticate with Claude (one-time)**
@@ -89,9 +88,10 @@ opencode
 
 ## Updating
 
-- **Homebrew:** `brew upgrade opencode-with-claude`. The formula in
-  [`Formula/`](Formula/opencode-with-claude.rb) is bumped automatically by the
-  release workflow, so `brew update && brew upgrade` tracks new releases.
+- **Homebrew:** `brew upgrade opencode-with-claude`. The release workflow
+  bumps [`Formula/opencode-with-claude.rb`](Formula/opencode-with-claude.rb)
+  and mirrors it to the [`ianjwhite99/homebrew-tap`](https://github.com/ianjwhite99/homebrew-tap)
+  tap, so `brew update && brew upgrade` tracks new releases.
 - **npm:** `npm update -g opencode-with-claude`. Note that OpenCode caches
   plugins it installs by package name; if a new version is not picked up,
   clear `~/.cache/opencode/node_modules/opencode-with-claude` and restart.
@@ -234,7 +234,7 @@ opencode-with-claude/
 │   ├── run.sh             # Test runner
 │   └── opencode.json      # Test config
 ├── Formula/
-│   └── opencode-with-claude.rb   # Homebrew formula (tap this repo)
+│   └── opencode-with-claude.rb   # Homebrew formula (mirrored to ianjwhite99/homebrew-tap)
 ├── scripts/
 │   └── update-homebrew-formula.sh # Bumps the formula after an npm release
 ├── package.json

--- a/README.md
+++ b/README.md
@@ -30,15 +30,25 @@ The plugin hooks into OpenCode's plugin system. When OpenCode launches, it start
 
 **1. Install the plugin**
 
+With npm:
+
 ```bash
 npm install -g opencode-with-claude
+```
+
+Or with [Homebrew](https://brew.sh) (macOS/Linux), which keeps the plugin
+updated through `brew upgrade` instead of `npm update -g`:
+
+```bash
+brew tap ianjwhite99/opencode-with-claude https://github.com/ianjwhite99/opencode-with-claude
+brew install opencode-with-claude
 ```
 
 **2. Authenticate with Claude (one-time)**
 
 ```bash
-npm install -g @anthropic-ai/claude-code
-claude auth login 
+npm install -g @anthropic-ai/claude-code   # or: brew install --cask claude-code
+claude auth login
 ```
 
 **3. Add to your `opencode.json`**
@@ -60,11 +70,31 @@ Global (`~/.config/opencode/opencode.json`) or project-level:
 }
 ```
 
-**3. Run OpenCode**
+If you installed with Homebrew, point the `plugin` entry at the installed
+file instead of the package name (the path is stable across upgrades, and
+`brew info opencode-with-claude` prints it):
+
+```json
+"plugin": ["file:///opt/homebrew/opt/opencode-with-claude/libexec/lib/node_modules/opencode-with-claude/dist/index.js"]
+```
+
+On Linux or Intel macOS replace `/opt/homebrew` with your Homebrew prefix
+(`brew --prefix`, usually `/home/linuxbrew/.linuxbrew` or `/usr/local`).
+
+**4. Run OpenCode**
 
 ```bash
 opencode
 ```
+
+## Updating
+
+- **Homebrew:** `brew upgrade opencode-with-claude`. The formula in
+  [`Formula/`](Formula/opencode-with-claude.rb) is bumped automatically by the
+  release workflow, so `brew update && brew upgrade` tracks new releases.
+- **npm:** `npm update -g opencode-with-claude`. Note that OpenCode caches
+  plugins it installs by package name; if a new version is not picked up,
+  clear `~/.cache/opencode/node_modules/opencode-with-claude` and restart.
 
 ## Profiles and SDK features
 
@@ -203,6 +233,10 @@ opencode-with-claude/
 ├── test/
 │   ├── run.sh             # Test runner
 │   └── opencode.json      # Test config
+├── Formula/
+│   └── opencode-with-claude.rb   # Homebrew formula (tap this repo)
+├── scripts/
+│   └── update-homebrew-formula.sh # Bumps the formula after an npm release
 ├── package.json
 └── tsconfig.json
 ```

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Point Formula/opencode-with-claude.rb at a published npm release.
+#
+# Downloads the tarball for the given version from the npm registry, computes
+# its sha256, and rewrites the formula's `url` and `sha256` lines. Run by the
+# Release workflow after `npm publish`; safe to run by hand as well.
+#
+# Usage:
+#   scripts/update-homebrew-formula.sh [version]   # defaults to package.json
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FORMULA="$REPO_ROOT/Formula/opencode-with-claude.rb"
+PACKAGE="opencode-with-claude"
+
+VERSION="${1:-$(node -p "require('$REPO_ROOT/package.json').version")}"
+VERSION="${VERSION#v}"
+URL="https://registry.npmjs.org/$PACKAGE/-/$PACKAGE-$VERSION.tgz"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+TARBALL="$TMP/$PACKAGE-$VERSION.tgz"
+
+# The registry can lag a few seconds behind `npm publish`; retry with backoff.
+delay=5
+for attempt in 1 2 3 4 5 6; do
+  if curl -fsSL --retry 2 -o "$TARBALL" "$URL"; then
+    break
+  fi
+  if [[ $attempt -eq 6 ]]; then
+    echo "error: could not download $URL after $attempt attempts" >&2
+    exit 1
+  fi
+  echo "tarball not available yet (attempt $attempt), retrying in ${delay}s..." >&2
+  sleep "$delay"
+  delay=$((delay * 2))
+done
+
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA256="$(sha256sum "$TARBALL" | awk '{print $1}')"
+else
+  SHA256="$(shasum -a 256 "$TARBALL" | awk '{print $1}')"
+fi
+
+if [[ ! "$SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "error: unexpected sha256 output: $SHA256" >&2
+  exit 1
+fi
+
+# Only the leading `url`/`sha256` lines of the formula (two-space indent) are
+# rewritten; anything inside `def`/`test` blocks is left alone.
+sed \
+  -e "s|^  url \".*\"$|  url \"$URL\"|" \
+  -e "s|^  sha256 \".*\"$|  sha256 \"$SHA256\"|" \
+  "$FORMULA" > "$TMP/formula.rb"
+
+if ! grep -qF "  url \"$URL\"" "$TMP/formula.rb" || \
+   ! grep -qF "  sha256 \"$SHA256\"" "$TMP/formula.rb"; then
+  echo "error: failed to rewrite url/sha256 in $FORMULA" >&2
+  exit 1
+fi
+
+mv "$TMP/formula.rb" "$FORMULA"
+echo "Formula updated: $PACKAGE $VERSION"
+echo "  url    $URL"
+echo "  sha256 $SHA256"


### PR DESCRIPTION
Add a Homebrew formula so the plugin can be installed and kept current with
`brew install` / `brew upgrade` instead of `npm update -g`.

- Formula/opencode-with-claude.rb installs the published npm tarball (with
  Meridian and the rest of its runtime deps) under libexec via std_npm_args
  and prints the stable `file://` plugin path to add to opencode.json.
- scripts/update-homebrew-formula.sh downloads a released tarball from the
  npm registry, computes its sha256 and rewrites the formula's url/sha256.
- The Release workflow runs that script after `npm publish` and commits the
  bumped formula back to main, so the tap tracks every release.
- README documents the tap, the Homebrew plugin path, and how to update.

Closes #193

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017zFm9WFs6L9NpvBvcZgD6W