### PR TITLE
fix: detach title-agent requests from the Meridian session lease

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,14 +98,26 @@ export const ClaudeMaxPlugin: Plugin = async ({ client }) => {
           ? agent.mode
           : agentModes.get(agentName.toLowerCase()) ?? "primary"
 
-      output.headers["x-opencode-session"] = incoming.sessionID
+      // OpenCode's title generator runs on the *same* session id as the user's
+      // first prompt, concurrently. Meridian serialises requests per session
+      // (a turn lease) and rejects whichever one waited with "This session
+      // advanced while the request was waiting" — about half the time that is
+      // the user's prompt, so the first message of a fresh session fails.
+      // Detach the title request: no session header means no lease, and the
+      // subagent mode marks it as an independent flow.
+      const isTitleRequest = agentName.toLowerCase() === "title"
+      if (!isTitleRequest) {
+        output.headers["x-opencode-session"] = incoming.sessionID
+      }
       output.headers["x-opencode-request"] = incoming.message.id
       output.headers["x-opencode-request-kind"] = humanMessages.has(
         messageKey(incoming.sessionID, incoming.message.id),
       )
         ? "human"
         : "synthetic"
-      output.headers["x-opencode-agent-mode"] = agentMode
+      output.headers["x-opencode-agent-mode"] = isTitleRequest
+        ? "subagent"
+        : agentMode
       output.headers["x-opencode-agent-name"] = agentName
     },
   }

--- a/test/unit/plugin-hooks.test.mjs
+++ b/test/unit/plugin-hooks.test.mjs
@@ -341,6 +341,29 @@ test("chat.headers strips non-ASCII before mode lookup", async () => {
   assert.equal(output.headers["x-opencode-agent-name"], "explore")
 })
 
+test("chat.headers detaches title-agent requests from the session lease", async () => {
+  // OpenCode titles a fresh session on the same session id, concurrently with
+  // the user's first prompt; Meridian's per-session turn lease then rejects
+  // whichever request waited. Title requests must carry no session header
+  // and declare subagent mode so Meridian treats them as independent.
+  for (const agent of ["title", { name: "title", mode: "primary" }]) {
+    const output = { headers: {} }
+    await hooks["chat.headers"](
+      {
+        sessionID: "sess-123",
+        model: { providerID: "anthropic" },
+        message: { id: "msg-title" },
+        agent,
+      },
+      output,
+    )
+    assert.equal(output.headers["x-opencode-session"], undefined)
+    assert.equal(output.headers["x-opencode-agent-mode"], "subagent")
+    assert.equal(output.headers["x-opencode-agent-name"], "title")
+    assert.equal(output.headers["x-opencode-request"], "msg-title")
+  }
+})
+
 test("chat.headers reads mode from runtime agent objects", async () => {
   const output = { headers: {} }
   await hooks["chat.headers"](


### PR DESCRIPTION
## What was broken

The first message of every fresh OpenCode session failed intermittently (roughly half the time) with:

```
This session advanced while the request was waiting. Retry with the latest conversation history or use a distinct session ID.
```

Second and later messages in the same session always worked.

## Why

On the first message, OpenCode fires its title generator (`agent=title`, small model) on the **same session id** as the user's prompt, concurrently. This plugin puts that session id in `x-opencode-session` on both requests, and Meridian serialises requests per session with a turn lease. Whichever request arrives second waits on the lease; when the first one commits, the waiter's messages no longer continue the committed lineage and Meridian rejects it. When the title request loses, nothing visible happens. When the user's prompt loses, the turn fails.

Meridian's opencode adapter only takes the lease when `x-opencode-session` is present, and treats `x-opencode-agent-mode: subagent` as an independent flow.

## The fix

In `chat.headers`, requests from the `title` agent no longer send `x-opencode-session` and declare `x-opencode-agent-mode: subagent`. The title request runs outside the lease, so the user's prompt is alone on it. Nothing else changes: the title request still gets `x-opencode-request`, `-request-kind` and `-agent-name`, and all other agents keep the session header.

Verified against a live setup (BranchLab driving `opencode acp`): 11 fresh sessions in a row completed after the change, versus ~50% failing before. Unit test added in `test/unit/plugin-hooks.test.mjs`.
